### PR TITLE
target event hash & equal

### DIFF
--- a/hackle-sdk-core/src/main/kotlin/io/hackle/sdk/core/model/TargetEvent.kt
+++ b/hackle-sdk-core/src/main/kotlin/io/hackle/sdk/core/model/TargetEvent.kt
@@ -1,5 +1,7 @@
 package io.hackle.sdk.core.model
 
+import java.util.Objects.hash
+
 /**
  * Audience 타겟팅을 위한 Event 객체
  *
@@ -34,4 +36,13 @@ data class TargetEvent(
         val date: Long,
         val count: Int
     )
+
+    override fun hashCode(): Int = hash(eventKey, property)
+
+    override fun equals(other: Any?): Boolean {
+        if (other !is TargetEvent) return false
+
+        return eventKey == other.eventKey &&
+                property == other.property
+    }
 }

--- a/hackle-sdk-core/src/test/kotlin/io/hackle/sdk/core/model/TargetEventTest.kt
+++ b/hackle-sdk-core/src/test/kotlin/io/hackle/sdk/core/model/TargetEventTest.kt
@@ -1,0 +1,46 @@
+package io.hackle.sdk.core.model
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import strikt.api.expectThat
+import strikt.assertions.isFalse
+import strikt.assertions.isTrue
+
+internal class TargetEventTest {
+
+    @Test
+    fun `is equal`() {
+        val targetEvent = TargetEvent("eventKey", listOf(TargetEvent.Stat(1, 2)))
+        val otherEvent = TargetEvent("eventKey", listOf(TargetEvent.Stat(1, 3)))
+
+        val targetEvent2 = TargetEvent("eventKey", listOf(TargetEvent.Stat(1, 2)), property = TargetEvent.Property("key", Target.Key.Type.EVENT_PROPERTY, "value"))
+        val otherEvent2 = TargetEvent("eventKey", listOf(TargetEvent.Stat(1, 3)), property = TargetEvent.Property("key", Target.Key.Type.EVENT_PROPERTY, "value"))
+
+        expectThat(targetEvent == otherEvent).isTrue()
+        expectThat(targetEvent2 == otherEvent2).isTrue()
+        expectThat(targetEvent.hashCode() == otherEvent.hashCode()).isTrue()
+        expectThat(targetEvent2.hashCode() == otherEvent2.hashCode()).isTrue()
+    }
+
+    @Test
+    fun `is not equal`() {
+        val targetEvent = TargetEvent("eventKey", listOf(TargetEvent.Stat(1, 2)))
+        val otherEvent = TargetEvent("otherEventKey", listOf(TargetEvent.Stat(1, 2)))
+
+        val targetEvent2 = TargetEvent("eventKey", listOf(TargetEvent.Stat(1, 2)), property = TargetEvent.Property("key", Target.Key.Type.EVENT_PROPERTY, "value"))
+        val otherEvent2 = TargetEvent("eventKey", listOf(TargetEvent.Stat(1, 2)), property = TargetEvent.Property("key", Target.Key.Type.EVENT_PROPERTY, "value2"))
+
+        expectThat(targetEvent == otherEvent).isFalse()
+        expectThat(targetEvent2 == otherEvent2).isFalse()
+        expectThat(targetEvent.hashCode() == otherEvent.hashCode()).isFalse()
+        expectThat(targetEvent2.hashCode() == otherEvent2.hashCode()).isFalse()
+
+        val targetEvent3 = TargetEvent("eventKey", listOf(TargetEvent.Stat(1, 2)), property = TargetEvent.Property("key", Target.Key.Type.EVENT_PROPERTY, "value"))
+        val otherAny = Any()
+
+        expectThat(targetEvent3 == otherAny).isFalse()
+    }
+
+
+}


### PR DESCRIPTION
## 개요
target event 객체를 비교할 때 event key와 property 정보만 사용하도록 수정

## 작업 내용
### hash와 equal 함수 수정
- `eventKey`와 `property` 만 사용하도록 수정하였습니다.
- 작업을 하다보니 polling 할 때 or 유저가 바뀔 때마다 서버에서는 현재 api 호출 시점에 전체 타겟 이벤트 정보를 내려주는데,
클라이언트에서 데이터를 항상 add만 하다보니 중복데이터가 생기는 문제가 있었습니다.
- 서버에서 내려주는 데이터를 최신 데이터로 보고 항상 overwrite 할 필요가 있습니다.
- `stats` 정보는 계속 바뀔 수 있기에 `eventKey`와 `property`만 사용해서 hash 생성 및 비교하도록 수정했습니다.