### PR TITLE
exist operator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ out/
 ### macOS ###
 .DS_Store
 .java-version
+
+.qodo

--- a/hackle-sdk-core/src/main/kotlin/io/hackle/sdk/core/evaluation/match/EventConditionMatcher.kt
+++ b/hackle-sdk-core/src/main/kotlin/io/hackle/sdk/core/evaluation/match/EventConditionMatcher.kt
@@ -37,7 +37,7 @@ internal class EventValueResolver {
             Target.Key.Type.FEATURE_FLAG,
             Target.Key.Type.COHORT,
             Target.Key.Type.NUMBER_OF_EVENTS_IN_DAYS,
-            Target.Key.Type.NUMBER_OF_EVENTS_WITH_PROPERTY_IN_DAYS-> throw IllegalArgumentException("Unsupported target key Type for EventValueResolver [${key.type}]")
+            Target.Key.Type.NUMBER_OF_EVENTS_WITH_PROPERTY_IN_DAYS -> throw IllegalArgumentException("Unsupported target key Type for EventValueResolver [${key.type}]")
         }
     }
 }

--- a/hackle-sdk-core/src/main/kotlin/io/hackle/sdk/core/evaluation/match/EventConditionMatcher.kt
+++ b/hackle-sdk-core/src/main/kotlin/io/hackle/sdk/core/evaluation/match/EventConditionMatcher.kt
@@ -19,8 +19,7 @@ internal class EventConditionMatcher(
         if (request !is Evaluator.EventRequest) {
             return false
         }
-        val eventValue = eventValueResolver.resolveOrNull(request.event, condition.key) ?: return false
-
+        val eventValue = eventValueResolver.resolveOrNull(request.event, condition.key)
         return valueOperatorMatcher.matches(eventValue, condition.match)
     }
 }

--- a/hackle-sdk-core/src/main/kotlin/io/hackle/sdk/core/evaluation/match/OperatorMatcher.kt
+++ b/hackle-sdk-core/src/main/kotlin/io/hackle/sdk/core/evaluation/match/OperatorMatcher.kt
@@ -1,67 +1,67 @@
 package io.hackle.sdk.core.evaluation.match
 
 internal interface OperatorMatcher {
-    fun matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: List<Any>): Boolean
+    fun matches(valueMatcher: ValueMatcher, userValue: Any?, matchValues: List<Any>): Boolean
 }
 
 internal object InMatcher : OperatorMatcher {
-    override fun matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: List<Any>): Boolean {
+    override fun matches(valueMatcher: ValueMatcher, userValue: Any?, matchValues: List<Any>): Boolean {
         if(userValue == null) return false
-        return matchValue.any { valueMatcher.inMatch(userValue, it) }
+        return matchValues.any { valueMatcher.inMatch(userValue, it) }
     }
 }
 
 internal object ContainsMatcher : OperatorMatcher {
-    override fun matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: List<Any>): Boolean {
+    override fun matches(valueMatcher: ValueMatcher, userValue: Any?, matchValues: List<Any>): Boolean {
         if(userValue == null) return false
-        return matchValue.any { valueMatcher.containsMatch(userValue, it) }
+        return matchValues.any { valueMatcher.containsMatch(userValue, it) }
     }
 }
 
 internal object StartsWithMatcher : OperatorMatcher {
-    override fun matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: List<Any>): Boolean {
+    override fun matches(valueMatcher: ValueMatcher, userValue: Any?, matchValues: List<Any>): Boolean {
         if(userValue == null) return false
-        return matchValue.any { valueMatcher.startsWithMatch(userValue, it) }
+        return matchValues.any { valueMatcher.startsWithMatch(userValue, it) }
     }
 }
 
 internal object EndsWithMatcher : OperatorMatcher {
-    override fun matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: List<Any>): Boolean {
+    override fun matches(valueMatcher: ValueMatcher, userValue: Any?, matchValues: List<Any>): Boolean {
         if(userValue == null) return false
-        return matchValue.any { valueMatcher.endsWithMatch(userValue, it) }
+        return matchValues.any { valueMatcher.endsWithMatch(userValue, it) }
     }
 }
 
 internal object GreaterThanMatcher : OperatorMatcher {
-    override fun matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: List<Any>): Boolean {
+    override fun matches(valueMatcher: ValueMatcher, userValue: Any?, matchValues: List<Any>): Boolean {
         if(userValue == null) return false
-        return matchValue.any { valueMatcher.greaterThanMatch(userValue, it) }
+        return matchValues.any { valueMatcher.greaterThanMatch(userValue, it) }
     }
 }
 
 internal object GreaterThanOrEqualToMatcher : OperatorMatcher {
-   override fun matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: List<Any>): Boolean {
+   override fun matches(valueMatcher: ValueMatcher, userValue: Any?, matchValues: List<Any>): Boolean {
        if(userValue == null) return false
-        return matchValue.any { valueMatcher.greaterThanOrEqualToMatch(userValue, it) }
+        return matchValues.any { valueMatcher.greaterThanOrEqualToMatch(userValue, it) }
     }
 }
 
 internal object LessThanMatcher : OperatorMatcher {
-    override fun matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: List<Any>): Boolean {
+    override fun matches(valueMatcher: ValueMatcher, userValue: Any?, matchValues: List<Any>): Boolean {
         if(userValue == null) return false
-        return matchValue.any { valueMatcher.lessThanMatch(userValue, it) }
+        return matchValues.any { valueMatcher.lessThanMatch(userValue, it) }
     }
 }
 
 internal object LessThanOrEqualToMatcher : OperatorMatcher {
-    override fun matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: List<Any>): Boolean {
+    override fun matches(valueMatcher: ValueMatcher, userValue: Any?, matchValues: List<Any>): Boolean {
         if(userValue == null) return false
-        return matchValue.any { valueMatcher.lessThanOrEqualToMatch(userValue, it) }
+        return matchValues.any { valueMatcher.lessThanOrEqualToMatch(userValue, it) }
     }
 }
 
 internal object ExistsMatcher : OperatorMatcher {
-    override fun matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: List<Any>): Boolean {
+    override fun matches(valueMatcher: ValueMatcher, userValue: Any?, matchValues: List<Any>): Boolean {
         return userValue != null
     }
 }

--- a/hackle-sdk-core/src/main/kotlin/io/hackle/sdk/core/evaluation/match/OperatorMatcher.kt
+++ b/hackle-sdk-core/src/main/kotlin/io/hackle/sdk/core/evaluation/match/OperatorMatcher.kt
@@ -6,54 +6,62 @@ internal interface OperatorMatcher {
 
 internal object InMatcher : OperatorMatcher {
     override fun matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: List<Any>): Boolean {
+        if(userValue == null) return false
         return matchValue.any { valueMatcher.inMatch(userValue, it) }
     }
 }
 
 internal object ContainsMatcher : OperatorMatcher {
     override fun matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: List<Any>): Boolean {
+        if(userValue == null) return false
         return matchValue.any { valueMatcher.containsMatch(userValue, it) }
     }
 }
 
 internal object StartsWithMatcher : OperatorMatcher {
     override fun matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: List<Any>): Boolean {
+        if(userValue == null) return false
         return matchValue.any { valueMatcher.startsWithMatch(userValue, it) }
     }
 }
 
 internal object EndsWithMatcher : OperatorMatcher {
     override fun matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: List<Any>): Boolean {
+        if(userValue == null) return false
         return matchValue.any { valueMatcher.endsWithMatch(userValue, it) }
     }
 }
 
 internal object GreaterThanMatcher : OperatorMatcher {
     override fun matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: List<Any>): Boolean {
+        if(userValue == null) return false
         return matchValue.any { valueMatcher.greaterThanMatch(userValue, it) }
     }
 }
 
 internal object GreaterThanOrEqualToMatcher : OperatorMatcher {
    override fun matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: List<Any>): Boolean {
+       if(userValue == null) return false
         return matchValue.any { valueMatcher.greaterThanOrEqualToMatch(userValue, it) }
     }
 }
 
 internal object LessThanMatcher : OperatorMatcher {
     override fun matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: List<Any>): Boolean {
+        if(userValue == null) return false
         return matchValue.any { valueMatcher.lessThanMatch(userValue, it) }
     }
 }
 
 internal object LessThanOrEqualToMatcher : OperatorMatcher {
     override fun matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: List<Any>): Boolean {
+        if(userValue == null) return false
         return matchValue.any { valueMatcher.lessThanOrEqualToMatch(userValue, it) }
     }
 }
 
 internal object ExistsMatcher : OperatorMatcher {
     override fun matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: List<Any>): Boolean {
-        return valueMatcher.existsMatch(userValue)
+        return userValue != null
     }
 }

--- a/hackle-sdk-core/src/main/kotlin/io/hackle/sdk/core/evaluation/match/OperatorMatcher.kt
+++ b/hackle-sdk-core/src/main/kotlin/io/hackle/sdk/core/evaluation/match/OperatorMatcher.kt
@@ -6,56 +6,56 @@ internal interface OperatorMatcher {
 
 internal object InMatcher : OperatorMatcher {
     override fun matches(valueMatcher: ValueMatcher, userValue: Any?, matchValues: List<Any>): Boolean {
-        if(userValue == null) return false
+        if (userValue == null) return false
         return matchValues.any { valueMatcher.inMatch(userValue, it) }
     }
 }
 
 internal object ContainsMatcher : OperatorMatcher {
     override fun matches(valueMatcher: ValueMatcher, userValue: Any?, matchValues: List<Any>): Boolean {
-        if(userValue == null) return false
+        if (userValue == null) return false
         return matchValues.any { valueMatcher.containsMatch(userValue, it) }
     }
 }
 
 internal object StartsWithMatcher : OperatorMatcher {
     override fun matches(valueMatcher: ValueMatcher, userValue: Any?, matchValues: List<Any>): Boolean {
-        if(userValue == null) return false
+        if (userValue == null) return false
         return matchValues.any { valueMatcher.startsWithMatch(userValue, it) }
     }
 }
 
 internal object EndsWithMatcher : OperatorMatcher {
     override fun matches(valueMatcher: ValueMatcher, userValue: Any?, matchValues: List<Any>): Boolean {
-        if(userValue == null) return false
+        if (userValue == null) return false
         return matchValues.any { valueMatcher.endsWithMatch(userValue, it) }
     }
 }
 
 internal object GreaterThanMatcher : OperatorMatcher {
     override fun matches(valueMatcher: ValueMatcher, userValue: Any?, matchValues: List<Any>): Boolean {
-        if(userValue == null) return false
+        if (userValue == null) return false
         return matchValues.any { valueMatcher.greaterThanMatch(userValue, it) }
     }
 }
 
 internal object GreaterThanOrEqualToMatcher : OperatorMatcher {
-   override fun matches(valueMatcher: ValueMatcher, userValue: Any?, matchValues: List<Any>): Boolean {
-       if(userValue == null) return false
+    override fun matches(valueMatcher: ValueMatcher, userValue: Any?, matchValues: List<Any>): Boolean {
+        if (userValue == null) return false
         return matchValues.any { valueMatcher.greaterThanOrEqualToMatch(userValue, it) }
     }
 }
 
 internal object LessThanMatcher : OperatorMatcher {
     override fun matches(valueMatcher: ValueMatcher, userValue: Any?, matchValues: List<Any>): Boolean {
-        if(userValue == null) return false
+        if (userValue == null) return false
         return matchValues.any { valueMatcher.lessThanMatch(userValue, it) }
     }
 }
 
 internal object LessThanOrEqualToMatcher : OperatorMatcher {
     override fun matches(valueMatcher: ValueMatcher, userValue: Any?, matchValues: List<Any>): Boolean {
-        if(userValue == null) return false
+        if (userValue == null) return false
         return matchValues.any { valueMatcher.lessThanOrEqualToMatch(userValue, it) }
     }
 }

--- a/hackle-sdk-core/src/main/kotlin/io/hackle/sdk/core/evaluation/match/OperatorMatcher.kt
+++ b/hackle-sdk-core/src/main/kotlin/io/hackle/sdk/core/evaluation/match/OperatorMatcher.kt
@@ -1,8 +1,5 @@
 package io.hackle.sdk.core.evaluation.match
 
-import io.hackle.sdk.core.model.Version
-
-
 internal interface OperatorMatcher {
     fun matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: List<Any>): Boolean
 }
@@ -58,12 +55,5 @@ internal object LessThanOrEqualToMatcher : OperatorMatcher {
 internal object ExistsMatcher : OperatorMatcher {
     override fun matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: List<Any>): Boolean {
         return valueMatcher.existsMatch(userValue)
-    }
-}
-
-
-internal object NotExistsMatcher : OperatorMatcher {
-    override fun matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: List<Any>): Boolean {
-        return valueMatcher.notExistsMatch(userValue)
     }
 }

--- a/hackle-sdk-core/src/main/kotlin/io/hackle/sdk/core/evaluation/match/OperatorMatcher.kt
+++ b/hackle-sdk-core/src/main/kotlin/io/hackle/sdk/core/evaluation/match/OperatorMatcher.kt
@@ -4,64 +4,66 @@ import io.hackle.sdk.core.model.Version
 
 
 internal interface OperatorMatcher {
-    fun matches(userValue: String, matchValue: String): Boolean
-    fun matches(userValue: Number, matchValue: Number): Boolean
-    fun matches(userValue: Boolean, matchValue: Boolean): Boolean
-    fun matches(userValue: Version, matchValue: Version): Boolean
+    fun matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: List<Any>): Boolean
 }
 
 internal object InMatcher : OperatorMatcher {
-    override fun matches(userValue: String, matchValue: String): Boolean = userValue == matchValue
-    override fun matches(userValue: Number, matchValue: Number): Boolean = userValue.toDouble() == matchValue.toDouble()
-    override fun matches(userValue: Boolean, matchValue: Boolean): Boolean = userValue == matchValue
-    override fun matches(userValue: Version, matchValue: Version): Boolean = userValue == matchValue
+    override fun matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: List<Any>): Boolean {
+        return matchValue.any { valueMatcher.inMatch(userValue, it) }
+    }
 }
 
 internal object ContainsMatcher : OperatorMatcher {
-    override fun matches(userValue: String, matchValue: String): Boolean = userValue.contains(matchValue)
-    override fun matches(userValue: Number, matchValue: Number): Boolean = false
-    override fun matches(userValue: Boolean, matchValue: Boolean): Boolean = false
-    override fun matches(userValue: Version, matchValue: Version): Boolean = false
+    override fun matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: List<Any>): Boolean {
+        return matchValue.any { valueMatcher.containsMatch(userValue, it) }
+    }
 }
 
 internal object StartsWithMatcher : OperatorMatcher {
-    override fun matches(userValue: String, matchValue: String): Boolean = userValue.startsWith(matchValue)
-    override fun matches(userValue: Number, matchValue: Number): Boolean = false
-    override fun matches(userValue: Boolean, matchValue: Boolean): Boolean = false
-    override fun matches(userValue: Version, matchValue: Version): Boolean = false
+    override fun matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: List<Any>): Boolean {
+        return matchValue.any { valueMatcher.startsWithMatch(userValue, it) }
+    }
 }
 
 internal object EndsWithMatcher : OperatorMatcher {
-    override fun matches(userValue: String, matchValue: String): Boolean = userValue.endsWith(matchValue)
-    override fun matches(userValue: Number, matchValue: Number): Boolean = false
-    override fun matches(userValue: Boolean, matchValue: Boolean): Boolean = false
-    override fun matches(userValue: Version, matchValue: Version): Boolean = false
+    override fun matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: List<Any>): Boolean {
+        return matchValue.any { valueMatcher.endsWithMatch(userValue, it) }
+    }
 }
 
 internal object GreaterThanMatcher : OperatorMatcher {
-    override fun matches(userValue: String, matchValue: String): Boolean = userValue > matchValue
-    override fun matches(userValue: Number, matchValue: Number): Boolean = userValue.toDouble() > matchValue.toDouble()
-    override fun matches(userValue: Boolean, matchValue: Boolean): Boolean = false
-    override fun matches(userValue: Version, matchValue: Version): Boolean = userValue > matchValue
+    override fun matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: List<Any>): Boolean {
+        return matchValue.any { valueMatcher.greaterThanMatch(userValue, it) }
+    }
 }
 
 internal object GreaterThanOrEqualToMatcher : OperatorMatcher {
-    override fun matches(userValue: String, matchValue: String): Boolean = userValue >= matchValue
-    override fun matches(userValue: Number, matchValue: Number): Boolean = userValue.toDouble() >= matchValue.toDouble()
-    override fun matches(userValue: Boolean, matchValue: Boolean): Boolean = false
-    override fun matches(userValue: Version, matchValue: Version): Boolean = userValue >= matchValue
+   override fun matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: List<Any>): Boolean {
+        return matchValue.any { valueMatcher.greaterThanOrEqualToMatch(userValue, it) }
+    }
 }
 
 internal object LessThanMatcher : OperatorMatcher {
-    override fun matches(userValue: String, matchValue: String): Boolean = userValue < matchValue
-    override fun matches(userValue: Number, matchValue: Number): Boolean = userValue.toDouble() < matchValue.toDouble()
-    override fun matches(userValue: Boolean, matchValue: Boolean): Boolean = false
-    override fun matches(userValue: Version, matchValue: Version): Boolean = userValue < matchValue
+    override fun matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: List<Any>): Boolean {
+        return matchValue.any { valueMatcher.lessThanMatch(userValue, it) }
+    }
 }
 
 internal object LessThanOrEqualToMatcher : OperatorMatcher {
-    override fun matches(userValue: String, matchValue: String): Boolean = userValue <= matchValue
-    override fun matches(userValue: Number, matchValue: Number): Boolean = userValue.toDouble() <= matchValue.toDouble()
-    override fun matches(userValue: Boolean, matchValue: Boolean): Boolean = false
-    override fun matches(userValue: Version, matchValue: Version): Boolean = userValue <= matchValue
+    override fun matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: List<Any>): Boolean {
+        return matchValue.any { valueMatcher.lessThanOrEqualToMatch(userValue, it) }
+    }
+}
+
+internal object ExistsMatcher : OperatorMatcher {
+    override fun matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: List<Any>): Boolean {
+        return valueMatcher.existsMatch(userValue)
+    }
+}
+
+
+internal object NotExistsMatcher : OperatorMatcher {
+    override fun matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: List<Any>): Boolean {
+        return valueMatcher.notExistsMatch(userValue)
+    }
 }

--- a/hackle-sdk-core/src/main/kotlin/io/hackle/sdk/core/evaluation/match/UserConditionMatcher.kt
+++ b/hackle-sdk-core/src/main/kotlin/io/hackle/sdk/core/evaluation/match/UserConditionMatcher.kt
@@ -21,7 +21,9 @@ internal class UserValueResolver {
             USER_ID -> user.identifiers[key.name]
             USER_PROPERTY -> user.properties[key.name]
             HACKLE_PROPERTY -> user.hackleProperties[key.name]
-            SEGMENT, AB_TEST, FEATURE_FLAG, EVENT_PROPERTY, COHORT, NUMBER_OF_EVENTS_IN_DAYS, NUMBER_OF_EVENTS_WITH_PROPERTY_IN_DAYS -> throw IllegalArgumentException("Unsupported target.key.type [${key.type}]")
+            SEGMENT, AB_TEST, FEATURE_FLAG, EVENT_PROPERTY, COHORT, NUMBER_OF_EVENTS_IN_DAYS, NUMBER_OF_EVENTS_WITH_PROPERTY_IN_DAYS -> throw IllegalArgumentException(
+                "Unsupported target.key.type [${key.type}]"
+            )
         }
     }
 }

--- a/hackle-sdk-core/src/main/kotlin/io/hackle/sdk/core/evaluation/match/UserConditionMatcher.kt
+++ b/hackle-sdk-core/src/main/kotlin/io/hackle/sdk/core/evaluation/match/UserConditionMatcher.kt
@@ -10,7 +10,7 @@ internal class UserConditionMatcher(
     private val valueOperatorMatcher: ValueOperatorMatcher
 ) : ConditionMatcher {
     override fun matches(request: Evaluator.Request, context: Evaluator.Context, condition: Target.Condition): Boolean {
-        val userValue = userValueResolver.resolveOrNull(request.user, condition.key) ?: return false
+        val userValue = userValueResolver.resolveOrNull(request.user, condition.key)
         return valueOperatorMatcher.matches(userValue, condition.match)
     }
 }

--- a/hackle-sdk-core/src/main/kotlin/io/hackle/sdk/core/evaluation/match/ValueMatcher.kt
+++ b/hackle-sdk-core/src/main/kotlin/io/hackle/sdk/core/evaluation/match/ValueMatcher.kt
@@ -7,203 +7,186 @@ import io.hackle.sdk.core.model.ValueConverter.asVersionOrNull
 
 
 internal interface ValueMatcher {
-    fun inMatch(userValue: Any?, matchValue: Any): Boolean
-    fun containsMatch(userValue: Any?, matchValue: Any): Boolean
-    fun startsWithMatch(userValue: Any?, matchValue: Any): Boolean
-    fun endsWithMatch(userValue: Any?, matchValue: Any): Boolean
-    fun greaterThanMatch(userValue: Any?, matchValue: Any): Boolean
-    fun greaterThanOrEqualToMatch(userValue: Any?, matchValue: Any): Boolean
-    fun lessThanMatch(userValue: Any?, matchValue: Any): Boolean
-    fun lessThanOrEqualToMatch(userValue: Any?, matchValue: Any): Boolean
-    fun existsMatch(userValue: Any?): Boolean
+    fun inMatch(userValue: Any, matchValue: Any): Boolean
+    fun containsMatch(userValue: Any, matchValue: Any): Boolean
+    fun startsWithMatch(userValue: Any, matchValue: Any): Boolean
+    fun endsWithMatch(userValue: Any, matchValue: Any): Boolean
+    fun greaterThanMatch(userValue: Any, matchValue: Any): Boolean
+    fun greaterThanOrEqualToMatch(userValue: Any, matchValue: Any): Boolean
+    fun lessThanMatch(userValue: Any, matchValue: Any): Boolean
+    fun lessThanOrEqualToMatch(userValue: Any, matchValue: Any): Boolean
 }
 
 internal object StringMatcher : ValueMatcher {
-    override fun inMatch(userValue: Any?, matchValue: Any): Boolean {
+    override fun inMatch(userValue: Any, matchValue: Any): Boolean {
         val userString = asStringOrNull(userValue) ?: return false
         val matchString = asStringOrNull(matchValue) ?: return false
         return userString == matchString
     }
 
-    override fun containsMatch(userValue: Any?, matchValue: Any): Boolean {
+    override fun containsMatch(userValue: Any, matchValue: Any): Boolean {
         val userString = asStringOrNull(userValue) ?: return false
         val matchString = asStringOrNull(matchValue) ?: return false
         return userString.contains(matchString)
     }
 
-    override fun startsWithMatch(userValue: Any?, matchValue: Any): Boolean {
+    override fun startsWithMatch(userValue: Any, matchValue: Any): Boolean {
         val userString = asStringOrNull(userValue) ?: return false
         val matchString = asStringOrNull(matchValue) ?: return false
         return userString.startsWith(matchString)
     }
 
-    override fun endsWithMatch(userValue: Any?, matchValue: Any): Boolean {
+    override fun endsWithMatch(userValue: Any, matchValue: Any): Boolean {
         val userString = asStringOrNull(userValue) ?: return false
         val matchString = asStringOrNull(matchValue) ?: return false
         return userString.endsWith(matchString)
     }
 
-    override fun greaterThanMatch(userValue: Any?, matchValue: Any): Boolean {
+    override fun greaterThanMatch(userValue: Any, matchValue: Any): Boolean {
         val userString = asStringOrNull(userValue) ?: return false
         val matchString = asStringOrNull(matchValue) ?: return false
         return userString > matchString
     }
 
-    override fun greaterThanOrEqualToMatch(userValue: Any?, matchValue: Any): Boolean {
+    override fun greaterThanOrEqualToMatch(userValue: Any, matchValue: Any): Boolean {
         val userString = asStringOrNull(userValue) ?: return false
         val matchString = asStringOrNull(matchValue) ?: return false
         return userString >= matchString
     }
 
-    override fun lessThanMatch(userValue: Any?, matchValue: Any): Boolean {
+    override fun lessThanMatch(userValue: Any, matchValue: Any): Boolean {
         val userString = asStringOrNull(userValue) ?: return false
         val matchString = asStringOrNull(matchValue) ?: return false
         return userString < matchString
     }
 
-    override fun lessThanOrEqualToMatch(userValue: Any?, matchValue: Any): Boolean {
+    override fun lessThanOrEqualToMatch(userValue: Any, matchValue: Any): Boolean {
         val userString = asStringOrNull(userValue) ?: return false
         val matchString = asStringOrNull(matchValue) ?: return false
         return userString <= matchString
     }
-
-    override fun existsMatch(userValue: Any?): Boolean {
-        return userValue != null
-    }
 }
 
 internal object NumberMatcher : ValueMatcher {
-    override fun inMatch(userValue: Any?, matchValue: Any): Boolean {
+    override fun inMatch(userValue: Any, matchValue: Any): Boolean {
         val userNumber = asDoubleOrNull(userValue) ?: return false
         val matchNumber = asDoubleOrNull(matchValue) ?: return false
         return userNumber == matchNumber
     }
 
-    override fun containsMatch(userValue: Any?, matchValue: Any): Boolean {
+    override fun containsMatch(userValue: Any, matchValue: Any): Boolean {
         return false
     }
 
-    override fun startsWithMatch(userValue: Any?, matchValue: Any): Boolean {
+    override fun startsWithMatch(userValue: Any, matchValue: Any): Boolean {
         return false
     }
 
-    override fun endsWithMatch(userValue: Any?, matchValue: Any): Boolean {
+    override fun endsWithMatch(userValue: Any, matchValue: Any): Boolean {
         return false
     }
 
-    override fun greaterThanMatch(userValue: Any?, matchValue: Any): Boolean {
+    override fun greaterThanMatch(userValue: Any, matchValue: Any): Boolean {
         val userNumber = asDoubleOrNull(userValue) ?: return false
         val matchNumber = asDoubleOrNull(matchValue) ?: return false
         return userNumber > matchNumber
     }
 
-    override fun greaterThanOrEqualToMatch(userValue: Any?, matchValue: Any): Boolean {
+    override fun greaterThanOrEqualToMatch(userValue: Any, matchValue: Any): Boolean {
         val userNumber = asDoubleOrNull(userValue) ?: return false
         val matchNumber = asDoubleOrNull(matchValue) ?: return false
         return userNumber >= matchNumber
     }
 
-    override fun lessThanMatch(userValue: Any?, matchValue: Any): Boolean {
+    override fun lessThanMatch(userValue: Any, matchValue: Any): Boolean {
         val userNumber = asDoubleOrNull(userValue) ?: return false
         val matchNumber = asDoubleOrNull(matchValue) ?: return false
         return userNumber < matchNumber
     }
 
-    override fun lessThanOrEqualToMatch(userValue: Any?, matchValue: Any): Boolean {
+    override fun lessThanOrEqualToMatch(userValue: Any, matchValue: Any): Boolean {
         val userNumber = asDoubleOrNull(userValue) ?: return false
         val matchNumber = asDoubleOrNull(matchValue) ?: return false
         return userNumber <= matchNumber
     }
-
-    override fun existsMatch(userValue: Any?): Boolean {
-        return userValue != null
-    }
 }
 
 internal object BooleanMatcher : ValueMatcher {
-    override fun inMatch(userValue: Any?, matchValue: Any): Boolean {
+    override fun inMatch(userValue: Any, matchValue: Any): Boolean {
         val userBoolean = asBooleanOrNull(userValue) ?: return false
         val matchBoolean = asBooleanOrNull(matchValue) ?: return false
         return userBoolean == matchBoolean
     }
 
-    override fun containsMatch(userValue: Any?, matchValue: Any): Boolean {
+    override fun containsMatch(userValue: Any, matchValue: Any): Boolean {
         return false
     }
 
-    override fun startsWithMatch(userValue: Any?, matchValue: Any): Boolean {
+    override fun startsWithMatch(userValue: Any, matchValue: Any): Boolean {
         return false
     }
 
-    override fun endsWithMatch(userValue: Any?, matchValue: Any): Boolean {
+    override fun endsWithMatch(userValue: Any, matchValue: Any): Boolean {
         return false
     }
 
-    override fun greaterThanMatch(userValue: Any?, matchValue: Any): Boolean {
+    override fun greaterThanMatch(userValue: Any, matchValue: Any): Boolean {
         return false
     }
 
-    override fun greaterThanOrEqualToMatch(userValue: Any?, matchValue: Any): Boolean {
+    override fun greaterThanOrEqualToMatch(userValue: Any, matchValue: Any): Boolean {
         return false
     }
 
-    override fun lessThanMatch(userValue: Any?, matchValue: Any): Boolean {
+    override fun lessThanMatch(userValue: Any, matchValue: Any): Boolean {
         return false
     }
 
-    override fun lessThanOrEqualToMatch(userValue: Any?, matchValue: Any): Boolean {
+    override fun lessThanOrEqualToMatch(userValue: Any, matchValue: Any): Boolean {
         return false
-    }
-
-    override fun existsMatch(userValue: Any?): Boolean {
-        return userValue != null
     }
 }
 
 internal object VersionMatcher : ValueMatcher {
-    override fun inMatch(userValue: Any?, matchValue: Any): Boolean {
+    override fun inMatch(userValue: Any, matchValue: Any): Boolean {
         val userVersion = asVersionOrNull(userValue) ?: return false
         val matchVersion = asVersionOrNull(matchValue) ?: return false
         return userVersion == matchVersion
     }
 
-    override fun containsMatch(userValue: Any?, matchValue: Any): Boolean {
+    override fun containsMatch(userValue: Any, matchValue: Any): Boolean {
         return false
     }
 
-    override fun startsWithMatch(userValue: Any?, matchValue: Any): Boolean {
+    override fun startsWithMatch(userValue: Any, matchValue: Any): Boolean {
         return false
     }
 
-    override fun endsWithMatch(userValue: Any?, matchValue: Any): Boolean {
+    override fun endsWithMatch(userValue: Any, matchValue: Any): Boolean {
         return false
     }
 
-    override fun greaterThanMatch(userValue: Any?, matchValue: Any): Boolean {
+    override fun greaterThanMatch(userValue: Any, matchValue: Any): Boolean {
         val userVersion = asVersionOrNull(userValue) ?: return false
         val matchVersion = asVersionOrNull(matchValue) ?: return false
         return userVersion > matchVersion
     }
 
-    override fun greaterThanOrEqualToMatch(userValue: Any?, matchValue: Any): Boolean {
+    override fun greaterThanOrEqualToMatch(userValue: Any, matchValue: Any): Boolean {
         val userVersion = asVersionOrNull(userValue) ?: return false
         val matchVersion = asVersionOrNull(matchValue) ?: return false
         return userVersion >= matchVersion
     }
 
-    override fun lessThanMatch(userValue: Any?, matchValue: Any): Boolean {
+    override fun lessThanMatch(userValue: Any, matchValue: Any): Boolean {
         val userVersion = asVersionOrNull(userValue) ?: return false
         val matchVersion = asVersionOrNull(matchValue) ?: return false
         return userVersion < matchVersion
     }
 
-    override fun lessThanOrEqualToMatch(userValue: Any?, matchValue: Any): Boolean {
+    override fun lessThanOrEqualToMatch(userValue: Any, matchValue: Any): Boolean {
         val userVersion = asVersionOrNull(userValue) ?: return false
         val matchVersion = asVersionOrNull(matchValue) ?: return false
         return userVersion <= matchVersion
-    }
-
-    override fun existsMatch(userValue: Any?): Boolean {
-        return userValue != null
     }
 }

--- a/hackle-sdk-core/src/main/kotlin/io/hackle/sdk/core/evaluation/match/ValueMatcher.kt
+++ b/hackle-sdk-core/src/main/kotlin/io/hackle/sdk/core/evaluation/match/ValueMatcher.kt
@@ -6,42 +6,222 @@ import io.hackle.sdk.core.model.ValueConverter.asStringOrNull
 import io.hackle.sdk.core.model.ValueConverter.asVersionOrNull
 
 
-internal fun interface ValueMatcher {
-    fun matches(operatorMatcher: OperatorMatcher, userValue: Any, matchValue: Any): Boolean
+internal interface ValueMatcher {
+    fun inMatch(userValue: Any?, matchValue: Any): Boolean
+    fun containsMatch(userValue: Any?, matchValue: Any): Boolean
+    fun startsWithMatch(userValue: Any?, matchValue: Any): Boolean
+    fun endsWithMatch(userValue: Any?, matchValue: Any): Boolean
+    fun greaterThanMatch(userValue: Any?, matchValue: Any): Boolean
+    fun greaterThanOrEqualToMatch(userValue: Any?, matchValue: Any): Boolean
+    fun lessThanMatch(userValue: Any?, matchValue: Any): Boolean
+    fun lessThanOrEqualToMatch(userValue: Any?, matchValue: Any): Boolean
+    fun existsMatch(userValue: Any?): Boolean
+    fun notExistsMatch(userValue: Any?): Boolean
 }
 
 internal object StringMatcher : ValueMatcher {
-    override fun matches(operatorMatcher: OperatorMatcher, userValue: Any, matchValue: Any): Boolean {
-        return operatorMatcher.matches(
-            userValue = asStringOrNull(userValue) ?: return false,
-            matchValue = asStringOrNull(matchValue) ?: return false
-        )
+    override fun inMatch(userValue: Any?, matchValue: Any): Boolean {
+        val userString = asStringOrNull(userValue) ?: return false
+        val matchString = asStringOrNull(matchValue) ?: return false
+        return userString == matchString
+    }
+
+    override fun containsMatch(userValue: Any?, matchValue: Any): Boolean {
+        val userString = asStringOrNull(userValue) ?: return false
+        val matchString = asStringOrNull(matchValue) ?: return false
+        return userString.contains(matchString)
+    }
+
+    override fun startsWithMatch(userValue: Any?, matchValue: Any): Boolean {
+        val userString = asStringOrNull(userValue) ?: return false
+        val matchString = asStringOrNull(matchValue) ?: return false
+        return userString.startsWith(matchString)
+    }
+
+    override fun endsWithMatch(userValue: Any?, matchValue: Any): Boolean {
+        val userString = asStringOrNull(userValue) ?: return false
+        val matchString = asStringOrNull(matchValue) ?: return false
+        return userString.endsWith(matchString)
+    }
+
+    override fun greaterThanMatch(userValue: Any?, matchValue: Any): Boolean {
+        val userString = asStringOrNull(userValue) ?: return false
+        val matchString = asStringOrNull(matchValue) ?: return false
+        return userString > matchString
+    }
+
+    override fun greaterThanOrEqualToMatch(userValue: Any?, matchValue: Any): Boolean {
+        val userString = asStringOrNull(userValue) ?: return false
+        val matchString = asStringOrNull(matchValue) ?: return false
+        return userString >= matchString
+    }
+
+    override fun lessThanMatch(userValue: Any?, matchValue: Any): Boolean {
+        val userString = asStringOrNull(userValue) ?: return false
+        val matchString = asStringOrNull(matchValue) ?: return false
+        return userString < matchString
+    }
+
+    override fun lessThanOrEqualToMatch(userValue: Any?, matchValue: Any): Boolean {
+        val userString = asStringOrNull(userValue) ?: return false
+        val matchString = asStringOrNull(matchValue) ?: return false
+        return userString <= matchString
+    }
+
+    override fun existsMatch(userValue: Any?): Boolean {
+        return userValue != null
+    }
+
+    override fun notExistsMatch(userValue: Any?): Boolean {
+        return userValue == null
     }
 }
 
 internal object NumberMatcher : ValueMatcher {
-    override fun matches(operatorMatcher: OperatorMatcher, userValue: Any, matchValue: Any): Boolean {
-        return operatorMatcher.matches(
-            userValue = asDoubleOrNull(userValue) ?: return false,
-            matchValue = asDoubleOrNull(matchValue) ?: return false
-        )
+    override fun inMatch(userValue: Any?, matchValue: Any): Boolean {
+        val userNumber = asDoubleOrNull(userValue) ?: return false
+        val matchNumber = asDoubleOrNull(matchValue) ?: return false
+        return userNumber == matchNumber
     }
+
+    override fun containsMatch(userValue: Any?, matchValue: Any): Boolean {
+        return false
+    }
+
+    override fun startsWithMatch(userValue: Any?, matchValue: Any): Boolean {
+        return false
+    }
+
+    override fun endsWithMatch(userValue: Any?, matchValue: Any): Boolean {
+        return false
+    }
+
+    override fun greaterThanMatch(userValue: Any?, matchValue: Any): Boolean {
+        val userNumber = asDoubleOrNull(userValue) ?: return false
+        val matchNumber = asDoubleOrNull(matchValue) ?: return false
+        return userNumber > matchNumber
+    }
+
+    override fun greaterThanOrEqualToMatch(userValue: Any?, matchValue: Any): Boolean {
+        val userNumber = asDoubleOrNull(userValue) ?: return false
+        val matchNumber = asDoubleOrNull(matchValue) ?: return false
+        return userNumber >= matchNumber
+    }
+
+    override fun lessThanMatch(userValue: Any?, matchValue: Any): Boolean {
+        val userNumber = asDoubleOrNull(userValue) ?: return false
+        val matchNumber = asDoubleOrNull(matchValue) ?: return false
+        return userNumber < matchNumber
+    }
+
+    override fun lessThanOrEqualToMatch(userValue: Any?, matchValue: Any): Boolean {
+        val userNumber = asDoubleOrNull(userValue) ?: return false
+        val matchNumber = asDoubleOrNull(matchValue) ?: return false
+        return userNumber <= matchNumber
+    }
+
+    override fun existsMatch(userValue: Any?): Boolean {
+        return userValue != null
+    }
+
+    override fun notExistsMatch(userValue: Any?): Boolean {
+        return userValue == null
+    }
+
 }
 
 internal object BooleanMatcher : ValueMatcher {
-    override fun matches(operatorMatcher: OperatorMatcher, userValue: Any, matchValue: Any): Boolean {
-        return operatorMatcher.matches(
-            userValue = asBooleanOrNull(userValue) ?: return false,
-            matchValue = asBooleanOrNull(matchValue) ?: return false
-        )
+    override fun inMatch(userValue: Any?, matchValue: Any): Boolean {
+        val userBoolean = asBooleanOrNull(userValue) ?: return false
+        val matchBoolean = asBooleanOrNull(matchValue) ?: return false
+        return userBoolean == matchBoolean
+    }
+
+    override fun containsMatch(userValue: Any?, matchValue: Any): Boolean {
+        return false
+    }
+
+    override fun startsWithMatch(userValue: Any?, matchValue: Any): Boolean {
+        return false
+    }
+
+    override fun endsWithMatch(userValue: Any?, matchValue: Any): Boolean {
+        return false
+    }
+
+    override fun greaterThanMatch(userValue: Any?, matchValue: Any): Boolean {
+        return false
+    }
+
+    override fun greaterThanOrEqualToMatch(userValue: Any?, matchValue: Any): Boolean {
+        return false
+    }
+
+    override fun lessThanMatch(userValue: Any?, matchValue: Any): Boolean {
+        return false
+    }
+
+    override fun lessThanOrEqualToMatch(userValue: Any?, matchValue: Any): Boolean {
+        return false
+    }
+
+    override fun existsMatch(userValue: Any?): Boolean {
+        return userValue != null
+    }
+
+    override fun notExistsMatch(userValue: Any?): Boolean {
+        return userValue == null
     }
 }
 
 internal object VersionMatcher : ValueMatcher {
-    override fun matches(operatorMatcher: OperatorMatcher, userValue: Any, matchValue: Any): Boolean {
-        return operatorMatcher.matches(
-            userValue = asVersionOrNull(userValue) ?: return false,
-            matchValue = asVersionOrNull(matchValue) ?: return false
-        )
+    override fun inMatch(userValue: Any?, matchValue: Any): Boolean {
+        val userVersion = asVersionOrNull(userValue) ?: return false
+        val matchVersion = asVersionOrNull(matchValue) ?: return false
+        return userVersion == matchVersion
+    }
+
+    override fun containsMatch(userValue: Any?, matchValue: Any): Boolean {
+        return false
+    }
+
+    override fun startsWithMatch(userValue: Any?, matchValue: Any): Boolean {
+        return false
+    }
+
+    override fun endsWithMatch(userValue: Any?, matchValue: Any): Boolean {
+        return false
+    }
+
+    override fun greaterThanMatch(userValue: Any?, matchValue: Any): Boolean {
+        val userVersion = asVersionOrNull(userValue) ?: return false
+        val matchVersion = asVersionOrNull(matchValue) ?: return false
+        return userVersion > matchVersion
+    }
+
+    override fun greaterThanOrEqualToMatch(userValue: Any?, matchValue: Any): Boolean {
+        val userVersion = asVersionOrNull(userValue) ?: return false
+        val matchVersion = asVersionOrNull(matchValue) ?: return false
+        return userVersion >= matchVersion
+    }
+
+    override fun lessThanMatch(userValue: Any?, matchValue: Any): Boolean {
+        val userVersion = asVersionOrNull(userValue) ?: return false
+        val matchVersion = asVersionOrNull(matchValue) ?: return false
+        return userVersion < matchVersion
+    }
+
+    override fun lessThanOrEqualToMatch(userValue: Any?, matchValue: Any): Boolean {
+        val userVersion = asVersionOrNull(userValue) ?: return false
+        val matchVersion = asVersionOrNull(matchValue) ?: return false
+        return userVersion <= matchVersion
+    }
+
+    override fun existsMatch(userValue: Any?): Boolean {
+        return userValue != null
+    }
+
+    override fun notExistsMatch(userValue: Any?): Boolean {
+        return userValue == null
     }
 }

--- a/hackle-sdk-core/src/main/kotlin/io/hackle/sdk/core/evaluation/match/ValueMatcher.kt
+++ b/hackle-sdk-core/src/main/kotlin/io/hackle/sdk/core/evaluation/match/ValueMatcher.kt
@@ -16,7 +16,6 @@ internal interface ValueMatcher {
     fun lessThanMatch(userValue: Any?, matchValue: Any): Boolean
     fun lessThanOrEqualToMatch(userValue: Any?, matchValue: Any): Boolean
     fun existsMatch(userValue: Any?): Boolean
-    fun notExistsMatch(userValue: Any?): Boolean
 }
 
 internal object StringMatcher : ValueMatcher {
@@ -71,10 +70,6 @@ internal object StringMatcher : ValueMatcher {
     override fun existsMatch(userValue: Any?): Boolean {
         return userValue != null
     }
-
-    override fun notExistsMatch(userValue: Any?): Boolean {
-        return userValue == null
-    }
 }
 
 internal object NumberMatcher : ValueMatcher {
@@ -123,11 +118,6 @@ internal object NumberMatcher : ValueMatcher {
     override fun existsMatch(userValue: Any?): Boolean {
         return userValue != null
     }
-
-    override fun notExistsMatch(userValue: Any?): Boolean {
-        return userValue == null
-    }
-
 }
 
 internal object BooleanMatcher : ValueMatcher {
@@ -167,10 +157,6 @@ internal object BooleanMatcher : ValueMatcher {
 
     override fun existsMatch(userValue: Any?): Boolean {
         return userValue != null
-    }
-
-    override fun notExistsMatch(userValue: Any?): Boolean {
-        return userValue == null
     }
 }
 
@@ -219,9 +205,5 @@ internal object VersionMatcher : ValueMatcher {
 
     override fun existsMatch(userValue: Any?): Boolean {
         return userValue != null
-    }
-
-    override fun notExistsMatch(userValue: Any?): Boolean {
-        return userValue == null
     }
 }

--- a/hackle-sdk-core/src/main/kotlin/io/hackle/sdk/core/evaluation/match/ValueOperatorMatcher.kt
+++ b/hackle-sdk-core/src/main/kotlin/io/hackle/sdk/core/evaluation/match/ValueOperatorMatcher.kt
@@ -7,7 +7,7 @@ internal class ValueOperatorMatcher(
     private val factory: ValueOperatorMatcherFactory
 ) {
 
-    fun matches(userValue: Any, match: Target.Match): Boolean {
+    fun matches(userValue: Any?, match: Target.Match): Boolean {
         val valueMatcher = factory.getValueMatcher(match.valueType)
         val operatorMatcher = factory.getOperatorMatcher(match.operator)
         @Suppress("UNCHECKED_CAST")
@@ -19,12 +19,12 @@ internal class ValueOperatorMatcher(
     }
 
     private fun singleMatches(
-        userValue: Any,
+        userValue: Any?,
         match: Target.Match,
         valueMatcher: ValueMatcher,
         operatorMatcher: OperatorMatcher
     ): Boolean {
-        return match.values.any { valueMatcher.matches(operatorMatcher, userValue, it) }
+        return operatorMatcher.matches(valueMatcher, userValue, match.values)
     }
 
     private fun arrayMatches(
@@ -58,6 +58,8 @@ internal class ValueOperatorMatcherFactory {
             Target.Match.Operator.GTE -> GreaterThanOrEqualToMatcher
             Target.Match.Operator.LT -> LessThanMatcher
             Target.Match.Operator.LTE -> LessThanOrEqualToMatcher
+            Target.Match.Operator.EXISTS -> ExistsMatcher
+            Target.Match.Operator.NOT_EXISTS -> NotExistsMatcher
         }
     }
 }

--- a/hackle-sdk-core/src/main/kotlin/io/hackle/sdk/core/evaluation/match/ValueOperatorMatcher.kt
+++ b/hackle-sdk-core/src/main/kotlin/io/hackle/sdk/core/evaluation/match/ValueOperatorMatcher.kt
@@ -59,7 +59,6 @@ internal class ValueOperatorMatcherFactory {
             Target.Match.Operator.LT -> LessThanMatcher
             Target.Match.Operator.LTE -> LessThanOrEqualToMatcher
             Target.Match.Operator.EXISTS -> ExistsMatcher
-            Target.Match.Operator.NOT_EXISTS -> NotExistsMatcher
         }
     }
 }

--- a/hackle-sdk-core/src/main/kotlin/io/hackle/sdk/core/evaluation/match/ValueOperatorMatcher.kt
+++ b/hackle-sdk-core/src/main/kotlin/io/hackle/sdk/core/evaluation/match/ValueOperatorMatcher.kt
@@ -10,6 +10,7 @@ internal class ValueOperatorMatcher(
     fun matches(userValue: Any?, match: Target.Match): Boolean {
         val valueMatcher = factory.getValueMatcher(match.valueType)
         val operatorMatcher = factory.getOperatorMatcher(match.operator)
+
         @Suppress("UNCHECKED_CAST")
         val isMatched = when (userValue) {
             is Collection<*> -> arrayMatches(userValue as Collection<Any>, match, valueMatcher, operatorMatcher)

--- a/hackle-sdk-core/src/main/kotlin/io/hackle/sdk/core/model/Target.kt
+++ b/hackle-sdk-core/src/main/kotlin/io/hackle/sdk/core/model/Target.kt
@@ -44,8 +44,7 @@ data class Target(
             GTE,
             LT,
             LTE,
-            EXISTS,
-            NOT_EXISTS,
+            EXISTS
         }
     }
 

--- a/hackle-sdk-core/src/main/kotlin/io/hackle/sdk/core/model/Target.kt
+++ b/hackle-sdk-core/src/main/kotlin/io/hackle/sdk/core/model/Target.kt
@@ -55,7 +55,7 @@ data class Target(
         /**
          * TargetEvent 에 해당하는 TargetSegmentationExpression
          */
-        sealed class NumberOfEventInDay: TargetSegmentationExpression() {
+        sealed class NumberOfEventInDay : TargetSegmentationExpression() {
             abstract val eventKey: String
             abstract val days: Int
 
@@ -65,7 +65,7 @@ data class Target(
             data class NumberOfEventsInDays(
                 override val eventKey: String,
                 override val days: Int
-            ): NumberOfEventInDay()
+            ) : NumberOfEventInDay()
 
             /**
              * NUMBER_OF_EVENTS_WITH_PROPERTY_IN_DAYS TargetSegmentationExpression
@@ -79,7 +79,7 @@ data class Target(
                  * EVENT_PROPERTY 타입만 허용됨
                  */
                 val propertyFilter: Condition
-            ): NumberOfEventInDay()
+            ) : NumberOfEventInDay()
         }
     }
 }

--- a/hackle-sdk-core/src/main/kotlin/io/hackle/sdk/core/model/Target.kt
+++ b/hackle-sdk-core/src/main/kotlin/io/hackle/sdk/core/model/Target.kt
@@ -44,6 +44,8 @@ data class Target(
             GTE,
             LT,
             LTE,
+            EXISTS,
+            NOT_EXISTS,
         }
     }
 

--- a/hackle-sdk-core/src/main/kotlin/io/hackle/sdk/core/model/ValueConverter.kt
+++ b/hackle-sdk-core/src/main/kotlin/io/hackle/sdk/core/model/ValueConverter.kt
@@ -1,7 +1,7 @@
 package io.hackle.sdk.core.model
 
 internal object ValueConverter {
-    fun asStringOrNull(value: Any?): String? {
+    fun asStringOrNull(value: Any): String? {
         return when (value) {
             is String -> return value
             is Number -> value.toString()
@@ -10,7 +10,7 @@ internal object ValueConverter {
         }
     }
 
-    fun asDoubleOrNull(value: Any?): Double? {
+    fun asDoubleOrNull(value: Any): Double? {
         return when (value) {
             is Double -> value
             is Number -> value.toDouble()
@@ -19,7 +19,7 @@ internal object ValueConverter {
         }
     }
 
-    fun asBooleanOrNull(value: Any?): Boolean? {
+    fun asBooleanOrNull(value: Any): Boolean? {
         return when (value) {
             is Boolean -> value
             is String -> value.toBoolean()
@@ -27,7 +27,7 @@ internal object ValueConverter {
         }
     }
 
-    fun asVersionOrNull(value: Any?): Version? {
+    fun asVersionOrNull(value: Any): Version? {
         return Version.parseOrNull(value)
     }
 

--- a/hackle-sdk-core/src/main/kotlin/io/hackle/sdk/core/model/ValueConverter.kt
+++ b/hackle-sdk-core/src/main/kotlin/io/hackle/sdk/core/model/ValueConverter.kt
@@ -1,7 +1,7 @@
 package io.hackle.sdk.core.model
 
 internal object ValueConverter {
-    fun asStringOrNull(value: Any): String? {
+    fun asStringOrNull(value: Any?): String? {
         return when (value) {
             is String -> return value
             is Number -> value.toString()
@@ -10,7 +10,7 @@ internal object ValueConverter {
         }
     }
 
-    fun asDoubleOrNull(value: Any): Double? {
+    fun asDoubleOrNull(value: Any?): Double? {
         return when (value) {
             is Double -> value
             is Number -> value.toDouble()
@@ -19,7 +19,7 @@ internal object ValueConverter {
         }
     }
 
-    fun asBooleanOrNull(value: Any): Boolean? {
+    fun asBooleanOrNull(value: Any?): Boolean? {
         return when (value) {
             is Boolean -> value
             is String -> value.toBoolean()
@@ -27,7 +27,7 @@ internal object ValueConverter {
         }
     }
 
-    fun asVersionOrNull(value: Any): Version? {
+    fun asVersionOrNull(value: Any?): Version? {
         return Version.parseOrNull(value)
     }
 

--- a/hackle-sdk-core/src/main/kotlin/io/hackle/sdk/core/model/Version.kt
+++ b/hackle-sdk-core/src/main/kotlin/io/hackle/sdk/core/model/Version.kt
@@ -76,7 +76,7 @@ internal class Version private constructor(
             return Version(coreVersion, prerelease, build)
         }
 
-        fun parseOrNull(value: Any): Version? {
+        fun parseOrNull(value: Any?): Version? {
             return when (value) {
                 is Version -> value
                 !is String -> null

--- a/hackle-sdk-core/src/main/kotlin/io/hackle/sdk/core/model/Version.kt
+++ b/hackle-sdk-core/src/main/kotlin/io/hackle/sdk/core/model/Version.kt
@@ -53,10 +53,10 @@ internal class Version private constructor(
         private val PATTERN: Pattern =
             Pattern.compile(
                 "^(0|[1-9]\\d*)" +
-                    "(?:\\.(0|[1-9]\\d*))?" +
-                    "(?:\\.(0|[1-9]\\d*))?" +
-                    "(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?" +
-                    "(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?\$"
+                        "(?:\\.(0|[1-9]\\d*))?" +
+                        "(?:\\.(0|[1-9]\\d*))?" +
+                        "(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?" +
+                        "(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?\$"
             )
 
         fun parseOrNull(version: String): Version? {

--- a/hackle-sdk-core/src/test/kotlin/io/hackle/sdk/core/evaluation/match/EventConditionMatcherTest.kt
+++ b/hackle-sdk-core/src/test/kotlin/io/hackle/sdk/core/evaluation/match/EventConditionMatcherTest.kt
@@ -89,21 +89,4 @@ internal class EventConditionMatcherTest {
 
         expectThat(result) isEqualTo true
     }
-
-    @Test
-    fun `프로퍼티 값이 없으면 false`() {
-        val request = mockk<Evaluator.EventRequest>()
-        val condition = mockk<Target.Condition>()
-
-        every { condition.key.type } returns Target.Key.Type.EVENT_PROPERTY
-        every { condition.match } returns mockk()
-        every { request.event } returns mockk()
-        every {
-            eventValueResolver.resolveOrNull(any(), any())
-        } returns null
-
-        val result = sut.matches(request, context, condition)
-
-        expectThat(result) isEqualTo false
-    }
 }

--- a/hackle-sdk-core/src/test/kotlin/io/hackle/sdk/core/evaluation/match/OperatorMatcherTest.kt
+++ b/hackle-sdk-core/src/test/kotlin/io/hackle/sdk/core/evaluation/match/OperatorMatcherTest.kt
@@ -15,41 +15,41 @@ internal class OperatorMatcherTest {
 
         @Test
         fun `string`() {
-            assertTrue(sut.matches(valueMatcher = StringMatcher, userValue = "abc", matchValue = listOf("abc")))
-            assertTrue(sut.matches(valueMatcher = StringMatcher, userValue = "abc", matchValue = listOf("abc", "def")))
-            assertFalse(sut.matches(valueMatcher = StringMatcher, userValue = "abc", matchValue = listOf("abc1")))
+            assertTrue(sut.matches(valueMatcher = StringMatcher, userValue = "abc", matchValues = listOf("abc")))
+            assertTrue(sut.matches(valueMatcher = StringMatcher, userValue = "abc", matchValues = listOf("abc", "def")))
+            assertFalse(sut.matches(valueMatcher = StringMatcher, userValue = "abc", matchValues = listOf("abc1")))
         }
 
         @Test
         fun `number`() {
-            assertTrue(sut.matches(valueMatcher = NumberMatcher, userValue = 320, matchValue = listOf(320)))
-            assertTrue(sut.matches(valueMatcher = NumberMatcher, userValue = 320.0, matchValue = listOf(320)))
-            assertTrue(sut.matches(valueMatcher = NumberMatcher, userValue = 320.1, matchValue = listOf(BigDecimal("320.10"))))
-            assertTrue(sut.matches(valueMatcher = NumberMatcher, userValue = BigDecimal("320.00"), matchValue = listOf(320)))
-            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = BigDecimal("320.01"), matchValue = listOf(320)))
-            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = 321, matchValue = listOf(320)))
+            assertTrue(sut.matches(valueMatcher = NumberMatcher, userValue = 320, matchValues = listOf(320)))
+            assertTrue(sut.matches(valueMatcher = NumberMatcher, userValue = 320.0, matchValues = listOf(320)))
+            assertTrue(sut.matches(valueMatcher = NumberMatcher, userValue = 320.1, matchValues = listOf(BigDecimal("320.10"))))
+            assertTrue(sut.matches(valueMatcher = NumberMatcher, userValue = BigDecimal("320.00"), matchValues = listOf(320)))
+            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = BigDecimal("320.01"), matchValues = listOf(320)))
+            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = 321, matchValues = listOf(320)))
         }
 
         @Test
         fun `boolean`() {
-            assertTrue(sut.matches(valueMatcher = BooleanMatcher, userValue = true, matchValue = listOf(true)))
-            assertTrue(sut.matches(valueMatcher = BooleanMatcher, userValue = false, matchValue = listOf(false)))
-            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = true, matchValue = listOf(false)))
-            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = false, matchValue = listOf(true)))
+            assertTrue(sut.matches(valueMatcher = BooleanMatcher, userValue = true, matchValues = listOf(true)))
+            assertTrue(sut.matches(valueMatcher = BooleanMatcher, userValue = false, matchValues = listOf(false)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = true, matchValues = listOf(false)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = false, matchValues = listOf(true)))
         }
 
         @Test
         fun `version`() {
-            assertTrue(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValue = listOf(v("1.0.0"))))
-            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValue = listOf(v("2.0.0"))))
+            assertTrue(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValues = listOf(v("1.0.0"))))
+            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValues = listOf(v("2.0.0"))))
         }
 
         @Test
         fun `if null fail`() {
-            assertFalse(sut.matches(valueMatcher = StringMatcher, userValue = null, matchValue = listOf("abc")))
-            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = null, matchValue = listOf(320)))
-            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = null, matchValue = listOf(true)))
-            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = null, matchValue = listOf(v("1.0.0"))))
+            assertFalse(sut.matches(valueMatcher = StringMatcher, userValue = null, matchValues = listOf("abc")))
+            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = null, matchValues = listOf(320)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = null, matchValues = listOf(true)))
+            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = null, matchValues = listOf(v("1.0.0"))))
         }
     }
 
@@ -60,41 +60,41 @@ internal class OperatorMatcherTest {
 
         @Test
         fun `string`() {
-            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "abc", matchValue = listOf("abc")))
-            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "abc", matchValue = listOf("a")))
-            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "abc", matchValue = listOf("b")))
-            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "abc", matchValue = listOf("c")))
-            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "abc", matchValue = listOf("ab")))
-            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "abc", matchValue = listOf("ac")))
-            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "a", matchValue = listOf("ab")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "abc", matchValues = listOf("abc")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "abc", matchValues = listOf("a")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "abc", matchValues = listOf("b")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "abc", matchValues = listOf("c")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "abc", matchValues = listOf("ab")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "abc", matchValues = listOf("ac")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "a", matchValues = listOf("ab")))
         }
 
         @Test
         fun `number`() {
-            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = 1, matchValue = listOf(1)))
-            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = 11, matchValue = listOf(1)))
+            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = 1, matchValues = listOf(1)))
+            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = 11, matchValues = listOf(1)))
         }
 
         @Test
         fun `boolean`() {
-            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = true, matchValue = listOf(true)))
-            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = false, matchValue = listOf(false)))
-            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = true, matchValue = listOf(false)))
-            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = false, matchValue = listOf(true)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = true, matchValues = listOf(true)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = false, matchValues = listOf(false)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = true, matchValues = listOf(false)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = false, matchValues = listOf(true)))
         }
 
         @Test
         fun `version`() {
-            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValue = listOf(v("1.0.0"))))
-            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValue = listOf(v("2.0.0"))))
+            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValues = listOf(v("1.0.0"))))
+            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValues = listOf(v("2.0.0"))))
         }
 
         @Test
         fun `if null fail`() {
-            assertFalse(sut.matches(valueMatcher = StringMatcher, userValue = null, matchValue = listOf("abc")))
-            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = null, matchValue = listOf(320)))
-            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = null, matchValue = listOf(true)))
-            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = null, matchValue = listOf(v("1.0.0"))))
+            assertFalse(sut.matches(valueMatcher = StringMatcher, userValue = null, matchValues = listOf("abc")))
+            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = null, matchValues = listOf(320)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = null, matchValues = listOf(true)))
+            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = null, matchValues = listOf(v("1.0.0"))))
         }
     }
 
@@ -105,38 +105,38 @@ internal class OperatorMatcherTest {
 
         @Test
         fun `string`() {
-            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "abc", matchValue = listOf("abc")))
-            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "abc", matchValue = listOf("a")))
-            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "abc", matchValue = listOf("b")))
-            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "a", matchValue = listOf("ab")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "abc", matchValues = listOf("abc")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "abc", matchValues = listOf("a")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "abc", matchValues = listOf("b")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "a", matchValues = listOf("ab")))
         }
 
         @Test
         fun `number`() {
-            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = 1, matchValue = listOf(1)))
-            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = 11, matchValue = listOf(1)))
+            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = 1, matchValues = listOf(1)))
+            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = 11, matchValues = listOf(1)))
         }
 
         @Test
         fun `boolean`() {
-            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = true, matchValue = listOf(true)))
-            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = false, matchValue = listOf(false)))
-            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = true, matchValue = listOf(false)))
-            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = false, matchValue = listOf(true)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = true, matchValues = listOf(true)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = false, matchValues = listOf(false)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = true, matchValues = listOf(false)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = false, matchValues = listOf(true)))
         }
 
         @Test
         fun `version`() {
-            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValue = listOf(v("1.0.0"))))
-            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValue = listOf(v("2.0.0"))))
+            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValues = listOf(v("1.0.0"))))
+            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValues = listOf(v("2.0.0"))))
         }
 
         @Test
         fun `if null fail`() {
-            assertFalse(sut.matches(valueMatcher = StringMatcher, userValue = null, matchValue = listOf("abc")))
-            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = null, matchValue = listOf(320)))
-            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = null, matchValue = listOf(true)))
-            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = null, matchValue = listOf(v("1.0.0"))))
+            assertFalse(sut.matches(valueMatcher = StringMatcher, userValue = null, matchValues = listOf("abc")))
+            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = null, matchValues = listOf(320)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = null, matchValues = listOf(true)))
+            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = null, matchValues = listOf(v("1.0.0"))))
         }
     }
 
@@ -147,39 +147,39 @@ internal class OperatorMatcherTest {
 
         @Test
         fun `string`() {
-            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "abc", matchValue = listOf("abc")))
-            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "abc", matchValue = listOf("a")))
-            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "abc", matchValue = listOf("c")))
-            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "abc", matchValue = listOf("bc")))
-            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "a", matchValue = listOf("ab")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "abc", matchValues = listOf("abc")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "abc", matchValues = listOf("a")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "abc", matchValues = listOf("c")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "abc", matchValues = listOf("bc")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "a", matchValues = listOf("ab")))
         }
 
         @Test
         fun `number`() {
-            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = 1, matchValue = listOf(1)))
-            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = 11, matchValue = listOf(1)))
+            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = 1, matchValues = listOf(1)))
+            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = 11, matchValues = listOf(1)))
         }
 
         @Test
         fun `boolean`() {
-            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = true, matchValue = listOf(true)))
-            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = false, matchValue = listOf(false)))
-            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = true, matchValue = listOf(false)))
-            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = false, matchValue = listOf(true)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = true, matchValues = listOf(true)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = false, matchValues = listOf(false)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = true, matchValues = listOf(false)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = false, matchValues = listOf(true)))
         }
 
         @Test
         fun `version`() {
-            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValue = listOf(v("1.0.0"))))
-            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValue = listOf(v("2.0.0"))))
+            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValues = listOf(v("1.0.0"))))
+            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValues = listOf(v("2.0.0"))))
         }
 
         @Test
         fun `if null fail`() {
-            assertFalse(sut.matches(valueMatcher = StringMatcher, userValue = null, matchValue = listOf("abc")))
-            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = null, matchValue = listOf(320)))
-            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = null, matchValue = listOf(true)))
-            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = null, matchValue = listOf(v("1.0.0"))))
+            assertFalse(sut.matches(valueMatcher = StringMatcher, userValue = null, matchValues = listOf("abc")))
+            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = null, matchValues = listOf(320)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = null, matchValues = listOf(true)))
+            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = null, matchValues = listOf(v("1.0.0"))))
         }
     }
 
@@ -190,54 +190,54 @@ internal class OperatorMatcherTest {
 
         @Test
         fun `string`() {
-            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "41", matchValue = listOf("42")))
-            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "42", matchValue = listOf("42")))
-            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "43", matchValue = listOf("42")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "41", matchValues = listOf("42")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "42", matchValues = listOf("42")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "43", matchValues = listOf("42")))
 
-            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "20230114", matchValue = listOf("20230115")))
-            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "20230115", matchValue = listOf("20230115")))
-            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "20230116", matchValue = listOf("20230115")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "20230114", matchValues = listOf("20230115")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "20230115", matchValues = listOf("20230115")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "20230116", matchValues = listOf("20230115")))
 
-            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "2023-01-14", matchValue = listOf("2023-01-15")))
-            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "2023-01-15", matchValue = listOf("2023-01-15")))
-            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "2023-01-16", matchValue = listOf("2023-01-15")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "2023-01-14", matchValues = listOf("2023-01-15")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "2023-01-15", matchValues = listOf("2023-01-15")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "2023-01-16", matchValues = listOf("2023-01-15")))
 
-            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "a", matchValue = listOf("a")))
-            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "a", matchValue = listOf("A")))
-            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "A", matchValue = listOf("a")))
-            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "aa", matchValue = listOf("a")))
-            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "a", matchValue = listOf("aa")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "a", matchValues = listOf("a")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "a", matchValues = listOf("A")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "A", matchValues = listOf("a")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "aa", matchValues = listOf("a")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "a", matchValues = listOf("aa")))
         }
 
         @Test
         fun `number`() {
-            assertTrue(sut.matches(valueMatcher = NumberMatcher, userValue = 1.001, matchValue = listOf(1)))
-            assertTrue(sut.matches(valueMatcher = NumberMatcher, userValue = 2, matchValue = listOf(1)))
-            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = 1, matchValue = listOf(1)))
-            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = 0.999, matchValue = listOf(1)))
+            assertTrue(sut.matches(valueMatcher = NumberMatcher, userValue = 1.001, matchValues = listOf(1)))
+            assertTrue(sut.matches(valueMatcher = NumberMatcher, userValue = 2, matchValues = listOf(1)))
+            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = 1, matchValues = listOf(1)))
+            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = 0.999, matchValues = listOf(1)))
         }
 
         @Test
         fun `boolean`() {
-            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = true, matchValue = listOf(true)))
-            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = false, matchValue = listOf(false)))
-            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = true, matchValue = listOf(false)))
-            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = false, matchValue = listOf(true)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = true, matchValues = listOf(true)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = false, matchValues = listOf(false)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = true, matchValues = listOf(false)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = false, matchValues = listOf(true)))
         }
 
         @Test
         fun `version`() {
-            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValue = listOf(v("1.0.0"))))
-            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValue = listOf(v("2.0.0"))))
-            assertTrue(sut.matches(valueMatcher = VersionMatcher, userValue = v("2.0.0"), matchValue = listOf(v("1.0.0"))))
+            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValues = listOf(v("1.0.0"))))
+            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValues = listOf(v("2.0.0"))))
+            assertTrue(sut.matches(valueMatcher = VersionMatcher, userValue = v("2.0.0"), matchValues = listOf(v("1.0.0"))))
         }
 
         @Test
         fun `if null fail`() {
-            assertFalse(sut.matches(valueMatcher = StringMatcher, userValue = null, matchValue = listOf("abc")))
-            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = null, matchValue = listOf(320)))
-            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = null, matchValue = listOf(true)))
-            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = null, matchValue = listOf(v("1.0.0"))))
+            assertFalse(sut.matches(valueMatcher = StringMatcher, userValue = null, matchValues = listOf("abc")))
+            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = null, matchValues = listOf(320)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = null, matchValues = listOf(true)))
+            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = null, matchValues = listOf(v("1.0.0"))))
         }
     }
 
@@ -248,54 +248,54 @@ internal class OperatorMatcherTest {
 
         @Test
         fun `string`() {
-            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "41", matchValue = listOf("42")))
-            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "42", matchValue = listOf("42")))
-            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "43", matchValue = listOf("42")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "41", matchValues = listOf("42")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "42", matchValues = listOf("42")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "43", matchValues = listOf("42")))
 
-            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "20230114", matchValue = listOf("20230115")))
-            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "20230115", matchValue = listOf("20230115")))
-            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "20230116", matchValue = listOf("20230115")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "20230114", matchValues = listOf("20230115")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "20230115", matchValues = listOf("20230115")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "20230116", matchValues = listOf("20230115")))
 
-            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "2023-01-14", matchValue = listOf("2023-01-15")))
-            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "2023-01-15", matchValue = listOf("2023-01-15")))
-            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "2023-01-16", matchValue = listOf("2023-01-15")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "2023-01-14", matchValues = listOf("2023-01-15")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "2023-01-15", matchValues = listOf("2023-01-15")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "2023-01-16", matchValues = listOf("2023-01-15")))
 
-            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "a", matchValue = listOf("a")))
-            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "a", matchValue = listOf("A")))
-            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "A", matchValue = listOf("a")))
-            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "aa", matchValue = listOf("a")))
-            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "a", matchValue = listOf("aa")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "a", matchValues = listOf("a")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "a", matchValues = listOf("A")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "A", matchValues = listOf("a")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "aa", matchValues = listOf("a")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "a", matchValues = listOf("aa")))
         }
 
         @Test
         fun `number`() {
-            assertTrue(sut.matches(valueMatcher = NumberMatcher, userValue = 1.001, matchValue = listOf(1)))
-            assertTrue(sut.matches(valueMatcher = NumberMatcher, userValue = 2, matchValue = listOf(1)))
-            assertTrue(sut.matches(valueMatcher = NumberMatcher, userValue = 1, matchValue = listOf(1)))
-            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = 0.999, matchValue = listOf(1)))
+            assertTrue(sut.matches(valueMatcher = NumberMatcher, userValue = 1.001, matchValues = listOf(1)))
+            assertTrue(sut.matches(valueMatcher = NumberMatcher, userValue = 2, matchValues = listOf(1)))
+            assertTrue(sut.matches(valueMatcher = NumberMatcher, userValue = 1, matchValues = listOf(1)))
+            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = 0.999, matchValues = listOf(1)))
         }
 
         @Test
         fun `boolean`() {
-            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = true, matchValue = listOf(true)))
-            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = false, matchValue = listOf(false)))
-            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = true, matchValue = listOf(false)))
-            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = false, matchValue = listOf(true)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = true, matchValues = listOf(true)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = false, matchValues = listOf(false)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = true, matchValues = listOf(false)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = false, matchValues = listOf(true)))
         }
 
         @Test
         fun `version`() {
-            assertTrue(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValue = listOf(v("1.0.0"))))
-            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValue = listOf(v("2.0.0"))))
-            assertTrue(sut.matches(valueMatcher = VersionMatcher, userValue = v("2.0.0"), matchValue = listOf(v("1.0.0"))))
+            assertTrue(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValues = listOf(v("1.0.0"))))
+            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValues = listOf(v("2.0.0"))))
+            assertTrue(sut.matches(valueMatcher = VersionMatcher, userValue = v("2.0.0"), matchValues = listOf(v("1.0.0"))))
         }
 
         @Test
         fun `if null fail`() {
-            assertFalse(sut.matches(valueMatcher = StringMatcher, userValue = null, matchValue = listOf("abc")))
-            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = null, matchValue = listOf(320)))
-            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = null, matchValue = listOf(true)))
-            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = null, matchValue = listOf(v("1.0.0"))))
+            assertFalse(sut.matches(valueMatcher = StringMatcher, userValue = null, matchValues = listOf("abc")))
+            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = null, matchValues = listOf(320)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = null, matchValues = listOf(true)))
+            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = null, matchValues = listOf(v("1.0.0"))))
         }
     }
 
@@ -306,54 +306,54 @@ internal class OperatorMatcherTest {
 
         @Test
         fun `string`() {
-            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "41", matchValue = listOf("42")))
-            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "42", matchValue = listOf("42")))
-            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "43", matchValue = listOf("42")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "41", matchValues = listOf("42")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "42", matchValues = listOf("42")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "43", matchValues = listOf("42")))
 
-            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "20230114", matchValue = listOf("20230115")))
-            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "20230115", matchValue = listOf("20230115")))
-            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "20230116", matchValue = listOf("20230115")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "20230114", matchValues = listOf("20230115")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "20230115", matchValues = listOf("20230115")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "20230116", matchValues = listOf("20230115")))
 
-            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "2023-01-14", matchValue = listOf("2023-01-15")))
-            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "2023-01-15", matchValue = listOf("2023-01-15")))
-            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "2023-01-16", matchValue = listOf("2023-01-15")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "2023-01-14", matchValues = listOf("2023-01-15")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "2023-01-15", matchValues = listOf("2023-01-15")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "2023-01-16", matchValues = listOf("2023-01-15")))
 
-            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "a", matchValue = listOf("a")))
-            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "a", matchValue = listOf("A")))
-            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "A", matchValue = listOf("a")))
-            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "aa", matchValue = listOf("a")))
-            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "a", matchValue = listOf("aa")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "a", matchValues = listOf("a")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "a", matchValues = listOf("A")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "A", matchValues = listOf("a")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "aa", matchValues = listOf("a")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "a", matchValues = listOf("aa")))
         }
 
         @Test
         fun `number`() {
-            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = 1.001, matchValue = listOf(1)))
-            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = 2, matchValue = listOf(1)))
-            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = 1, matchValue = listOf(1)))
-            assertTrue(sut.matches(valueMatcher = NumberMatcher, userValue = 0.999, matchValue = listOf(1)))
+            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = 1.001, matchValues = listOf(1)))
+            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = 2, matchValues = listOf(1)))
+            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = 1, matchValues = listOf(1)))
+            assertTrue(sut.matches(valueMatcher = NumberMatcher, userValue = 0.999, matchValues = listOf(1)))
         }
 
         @Test
         fun `boolean`() {
-            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = true, matchValue = listOf(true)))
-            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = false, matchValue = listOf(false)))
-            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = true, matchValue = listOf(false)))
-            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = false, matchValue = listOf(true)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = true, matchValues = listOf(true)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = false, matchValues = listOf(false)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = true, matchValues = listOf(false)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = false, matchValues = listOf(true)))
         }
 
         @Test
         fun `version`() {
-            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValue = listOf(v("1.0.0"))))
-            assertTrue(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValue = listOf(v("2.0.0"))))
-            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = v("2.0.0"), matchValue = listOf(v("1.0.0"))))
+            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValues = listOf(v("1.0.0"))))
+            assertTrue(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValues = listOf(v("2.0.0"))))
+            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = v("2.0.0"), matchValues = listOf(v("1.0.0"))))
         }
 
         @Test
         fun `if null fail`() {
-            assertFalse(sut.matches(valueMatcher = StringMatcher, userValue = null, matchValue = listOf("abc")))
-            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = null, matchValue = listOf(320)))
-            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = null, matchValue = listOf(true)))
-            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = null, matchValue = listOf(v("1.0.0"))))
+            assertFalse(sut.matches(valueMatcher = StringMatcher, userValue = null, matchValues = listOf("abc")))
+            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = null, matchValues = listOf(320)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = null, matchValues = listOf(true)))
+            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = null, matchValues = listOf(v("1.0.0"))))
         }
     }
 
@@ -364,54 +364,54 @@ internal class OperatorMatcherTest {
 
         @Test
         fun `string`() {
-            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "41", matchValue = listOf("42")))
-            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "42", matchValue = listOf("42")))
-            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "43", matchValue = listOf("42")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "41", matchValues = listOf("42")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "42", matchValues = listOf("42")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "43", matchValues = listOf("42")))
 
-            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "20230114", matchValue = listOf("20230115")))
-            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "20230115", matchValue = listOf("20230115")))
-            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "20230116", matchValue = listOf("20230115")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "20230114", matchValues = listOf("20230115")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "20230115", matchValues = listOf("20230115")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "20230116", matchValues = listOf("20230115")))
 
-            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "2023-01-14", matchValue = listOf("2023-01-15")))
-            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "2023-01-15", matchValue = listOf("2023-01-15")))
-            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "2023-01-16", matchValue = listOf("2023-01-15")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "2023-01-14", matchValues = listOf("2023-01-15")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "2023-01-15", matchValues = listOf("2023-01-15")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "2023-01-16", matchValues = listOf("2023-01-15")))
 
-            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "a", matchValue = listOf("a")))
-            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "a", matchValue = listOf("A")))
-            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "A", matchValue = listOf("a")))
-            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "aa", matchValue = listOf("a")))
-            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "a", matchValue = listOf("aa")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "a", matchValues = listOf("a")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "a", matchValues = listOf("A")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "A", matchValues = listOf("a")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "aa", matchValues = listOf("a")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "a", matchValues = listOf("aa")))
         }
 
         @Test
         fun `number`() {
-            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = 1.001, matchValue = listOf(1)))
-            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = 2, matchValue = listOf(1)))
-            assertTrue(sut.matches(valueMatcher = NumberMatcher, userValue = 1, matchValue = listOf(1)))
-            assertTrue(sut.matches(valueMatcher = NumberMatcher, userValue = 0.999, matchValue = listOf(1)))
+            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = 1.001, matchValues = listOf(1)))
+            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = 2, matchValues = listOf(1)))
+            assertTrue(sut.matches(valueMatcher = NumberMatcher, userValue = 1, matchValues = listOf(1)))
+            assertTrue(sut.matches(valueMatcher = NumberMatcher, userValue = 0.999, matchValues = listOf(1)))
         }
 
         @Test
         fun `boolean`() {
-            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = true, matchValue = listOf(true)))
-            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = false, matchValue = listOf(false)))
-            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = true, matchValue = listOf(false)))
-            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = false, matchValue = listOf(true)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = true, matchValues = listOf(true)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = false, matchValues = listOf(false)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = true, matchValues = listOf(false)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = false, matchValues = listOf(true)))
         }
 
         @Test
         fun `version`() {
-            assertTrue(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValue = listOf(v("1.0.0"))))
-            assertTrue(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValue = listOf(v("2.0.0"))))
-            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = v("2.0.0"), matchValue = listOf(v("1.0.0"))))
+            assertTrue(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValues = listOf(v("1.0.0"))))
+            assertTrue(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValues = listOf(v("2.0.0"))))
+            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = v("2.0.0"), matchValues = listOf(v("1.0.0"))))
         }
 
         @Test
         fun `if null fail`() {
-            assertFalse(sut.matches(valueMatcher = StringMatcher, userValue = null, matchValue = listOf("abc")))
-            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = null, matchValue = listOf(320)))
-            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = null, matchValue = listOf(true)))
-            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = null, matchValue = listOf(v("1.0.0"))))
+            assertFalse(sut.matches(valueMatcher = StringMatcher, userValue = null, matchValues = listOf("abc")))
+            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = null, matchValues = listOf(320)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = null, matchValues = listOf(true)))
+            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = null, matchValues = listOf(v("1.0.0"))))
         }
     }
 
@@ -419,33 +419,33 @@ internal class OperatorMatcherTest {
     inner class ExistMatcherTest() {
         @Test
         fun `if null fail`() {
-            assertFalse(ExistsMatcher.matches(valueMatcher = StringMatcher, userValue = null, matchValue = emptyList()))
-            assertFalse(ExistsMatcher.matches(valueMatcher = NumberMatcher, userValue = null, matchValue = emptyList()))
-            assertFalse(ExistsMatcher.matches(valueMatcher = BooleanMatcher, userValue = null, matchValue = emptyList()))
-            assertFalse(ExistsMatcher.matches(valueMatcher = VersionMatcher, userValue = null, matchValue = emptyList()))
+            assertFalse(ExistsMatcher.matches(valueMatcher = StringMatcher, userValue = null, matchValues = emptyList()))
+            assertFalse(ExistsMatcher.matches(valueMatcher = NumberMatcher, userValue = null, matchValues = emptyList()))
+            assertFalse(ExistsMatcher.matches(valueMatcher = BooleanMatcher, userValue = null, matchValues = emptyList()))
+            assertFalse(ExistsMatcher.matches(valueMatcher = VersionMatcher, userValue = null, matchValues = emptyList()))
         }
 
         @Test
         fun `if not null success`() {
-            assertTrue(ExistsMatcher.matches(valueMatcher = StringMatcher, userValue = "abc", matchValue = emptyList()))
-            assertTrue(ExistsMatcher.matches(valueMatcher = StringMatcher, userValue = 320, matchValue = emptyList()))
-            assertTrue(ExistsMatcher.matches(valueMatcher = StringMatcher, userValue = true, matchValue = emptyList()))
-            assertTrue(ExistsMatcher.matches(valueMatcher = StringMatcher, userValue = v("1.0.0"), matchValue = emptyList()))
+            assertTrue(ExistsMatcher.matches(valueMatcher = StringMatcher, userValue = "abc", matchValues = emptyList()))
+            assertTrue(ExistsMatcher.matches(valueMatcher = StringMatcher, userValue = 320, matchValues = emptyList()))
+            assertTrue(ExistsMatcher.matches(valueMatcher = StringMatcher, userValue = true, matchValues = emptyList()))
+            assertTrue(ExistsMatcher.matches(valueMatcher = StringMatcher, userValue = v("1.0.0"), matchValues = emptyList()))
 
-            assertTrue(ExistsMatcher.matches(valueMatcher = NumberMatcher, userValue = "abc", matchValue = emptyList()))
-            assertTrue(ExistsMatcher.matches(valueMatcher = NumberMatcher, userValue = 320, matchValue = emptyList()))
-            assertTrue(ExistsMatcher.matches(valueMatcher = NumberMatcher, userValue = true, matchValue = emptyList()))
-            assertTrue(ExistsMatcher.matches(valueMatcher = NumberMatcher, userValue = v("1.0.0"), matchValue = emptyList()))
+            assertTrue(ExistsMatcher.matches(valueMatcher = NumberMatcher, userValue = "abc", matchValues = emptyList()))
+            assertTrue(ExistsMatcher.matches(valueMatcher = NumberMatcher, userValue = 320, matchValues = emptyList()))
+            assertTrue(ExistsMatcher.matches(valueMatcher = NumberMatcher, userValue = true, matchValues = emptyList()))
+            assertTrue(ExistsMatcher.matches(valueMatcher = NumberMatcher, userValue = v("1.0.0"), matchValues = emptyList()))
 
-            assertTrue(ExistsMatcher.matches(valueMatcher = BooleanMatcher, userValue = "abc", matchValue = emptyList()))
-            assertTrue(ExistsMatcher.matches(valueMatcher = BooleanMatcher, userValue = 320, matchValue = emptyList()))
-            assertTrue(ExistsMatcher.matches(valueMatcher = BooleanMatcher, userValue = true, matchValue = emptyList()))
-            assertTrue(ExistsMatcher.matches(valueMatcher = BooleanMatcher, userValue = v("1.0.0"), matchValue = emptyList()))
+            assertTrue(ExistsMatcher.matches(valueMatcher = BooleanMatcher, userValue = "abc", matchValues = emptyList()))
+            assertTrue(ExistsMatcher.matches(valueMatcher = BooleanMatcher, userValue = 320, matchValues = emptyList()))
+            assertTrue(ExistsMatcher.matches(valueMatcher = BooleanMatcher, userValue = true, matchValues = emptyList()))
+            assertTrue(ExistsMatcher.matches(valueMatcher = BooleanMatcher, userValue = v("1.0.0"), matchValues = emptyList()))
 
-            assertTrue(ExistsMatcher.matches(valueMatcher = VersionMatcher, userValue = "abc", matchValue = emptyList()))
-            assertTrue(ExistsMatcher.matches(valueMatcher = VersionMatcher, userValue = 320, matchValue = emptyList()))
-            assertTrue(ExistsMatcher.matches(valueMatcher = VersionMatcher, userValue = true, matchValue = emptyList()))
-            assertTrue(ExistsMatcher.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValue = emptyList()))
+            assertTrue(ExistsMatcher.matches(valueMatcher = VersionMatcher, userValue = "abc", matchValues = emptyList()))
+            assertTrue(ExistsMatcher.matches(valueMatcher = VersionMatcher, userValue = 320, matchValues = emptyList()))
+            assertTrue(ExistsMatcher.matches(valueMatcher = VersionMatcher, userValue = true, matchValues = emptyList()))
+            assertTrue(ExistsMatcher.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValues = emptyList()))
         }
     }
 

--- a/hackle-sdk-core/src/test/kotlin/io/hackle/sdk/core/evaluation/match/OperatorMatcherTest.kt
+++ b/hackle-sdk-core/src/test/kotlin/io/hackle/sdk/core/evaluation/match/OperatorMatcherTest.kt
@@ -43,6 +43,14 @@ internal class OperatorMatcherTest {
             assertTrue(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValue = listOf(v("1.0.0"))))
             assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValue = listOf(v("2.0.0"))))
         }
+
+        @Test
+        fun `if null fail`() {
+            assertFalse(sut.matches(valueMatcher = StringMatcher, userValue = null, matchValue = listOf("abc")))
+            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = null, matchValue = listOf(320)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = null, matchValue = listOf(true)))
+            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = null, matchValue = listOf(v("1.0.0"))))
+        }
     }
 
     @Nested
@@ -80,6 +88,14 @@ internal class OperatorMatcherTest {
             assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValue = listOf(v("1.0.0"))))
             assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValue = listOf(v("2.0.0"))))
         }
+
+        @Test
+        fun `if null fail`() {
+            assertFalse(sut.matches(valueMatcher = StringMatcher, userValue = null, matchValue = listOf("abc")))
+            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = null, matchValue = listOf(320)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = null, matchValue = listOf(true)))
+            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = null, matchValue = listOf(v("1.0.0"))))
+        }
     }
 
     @Nested
@@ -113,6 +129,14 @@ internal class OperatorMatcherTest {
         fun `version`() {
             assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValue = listOf(v("1.0.0"))))
             assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValue = listOf(v("2.0.0"))))
+        }
+
+        @Test
+        fun `if null fail`() {
+            assertFalse(sut.matches(valueMatcher = StringMatcher, userValue = null, matchValue = listOf("abc")))
+            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = null, matchValue = listOf(320)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = null, matchValue = listOf(true)))
+            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = null, matchValue = listOf(v("1.0.0"))))
         }
     }
 
@@ -148,6 +172,14 @@ internal class OperatorMatcherTest {
         fun `version`() {
             assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValue = listOf(v("1.0.0"))))
             assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValue = listOf(v("2.0.0"))))
+        }
+
+        @Test
+        fun `if null fail`() {
+            assertFalse(sut.matches(valueMatcher = StringMatcher, userValue = null, matchValue = listOf("abc")))
+            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = null, matchValue = listOf(320)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = null, matchValue = listOf(true)))
+            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = null, matchValue = listOf(v("1.0.0"))))
         }
     }
 
@@ -199,6 +231,14 @@ internal class OperatorMatcherTest {
             assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValue = listOf(v("2.0.0"))))
             assertTrue(sut.matches(valueMatcher = VersionMatcher, userValue = v("2.0.0"), matchValue = listOf(v("1.0.0"))))
         }
+
+        @Test
+        fun `if null fail`() {
+            assertFalse(sut.matches(valueMatcher = StringMatcher, userValue = null, matchValue = listOf("abc")))
+            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = null, matchValue = listOf(320)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = null, matchValue = listOf(true)))
+            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = null, matchValue = listOf(v("1.0.0"))))
+        }
     }
 
     @Nested
@@ -248,6 +288,14 @@ internal class OperatorMatcherTest {
             assertTrue(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValue = listOf(v("1.0.0"))))
             assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValue = listOf(v("2.0.0"))))
             assertTrue(sut.matches(valueMatcher = VersionMatcher, userValue = v("2.0.0"), matchValue = listOf(v("1.0.0"))))
+        }
+
+        @Test
+        fun `if null fail`() {
+            assertFalse(sut.matches(valueMatcher = StringMatcher, userValue = null, matchValue = listOf("abc")))
+            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = null, matchValue = listOf(320)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = null, matchValue = listOf(true)))
+            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = null, matchValue = listOf(v("1.0.0"))))
         }
     }
 
@@ -299,6 +347,14 @@ internal class OperatorMatcherTest {
             assertTrue(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValue = listOf(v("2.0.0"))))
             assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = v("2.0.0"), matchValue = listOf(v("1.0.0"))))
         }
+
+        @Test
+        fun `if null fail`() {
+            assertFalse(sut.matches(valueMatcher = StringMatcher, userValue = null, matchValue = listOf("abc")))
+            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = null, matchValue = listOf(320)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = null, matchValue = listOf(true)))
+            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = null, matchValue = listOf(v("1.0.0"))))
+        }
     }
 
     @Nested
@@ -348,6 +404,48 @@ internal class OperatorMatcherTest {
             assertTrue(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValue = listOf(v("1.0.0"))))
             assertTrue(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValue = listOf(v("2.0.0"))))
             assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = v("2.0.0"), matchValue = listOf(v("1.0.0"))))
+        }
+
+        @Test
+        fun `if null fail`() {
+            assertFalse(sut.matches(valueMatcher = StringMatcher, userValue = null, matchValue = listOf("abc")))
+            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = null, matchValue = listOf(320)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = null, matchValue = listOf(true)))
+            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = null, matchValue = listOf(v("1.0.0"))))
+        }
+    }
+
+    @Nested
+    inner class ExistMatcherTest() {
+        @Test
+        fun `if null fail`() {
+            assertFalse(ExistsMatcher.matches(valueMatcher = StringMatcher, userValue = null, matchValue = emptyList()))
+            assertFalse(ExistsMatcher.matches(valueMatcher = NumberMatcher, userValue = null, matchValue = emptyList()))
+            assertFalse(ExistsMatcher.matches(valueMatcher = BooleanMatcher, userValue = null, matchValue = emptyList()))
+            assertFalse(ExistsMatcher.matches(valueMatcher = VersionMatcher, userValue = null, matchValue = emptyList()))
+        }
+
+        @Test
+        fun `if not null success`() {
+            assertTrue(ExistsMatcher.matches(valueMatcher = StringMatcher, userValue = "abc", matchValue = emptyList()))
+            assertTrue(ExistsMatcher.matches(valueMatcher = StringMatcher, userValue = 320, matchValue = emptyList()))
+            assertTrue(ExistsMatcher.matches(valueMatcher = StringMatcher, userValue = true, matchValue = emptyList()))
+            assertTrue(ExistsMatcher.matches(valueMatcher = StringMatcher, userValue = v("1.0.0"), matchValue = emptyList()))
+
+            assertTrue(ExistsMatcher.matches(valueMatcher = NumberMatcher, userValue = "abc", matchValue = emptyList()))
+            assertTrue(ExistsMatcher.matches(valueMatcher = NumberMatcher, userValue = 320, matchValue = emptyList()))
+            assertTrue(ExistsMatcher.matches(valueMatcher = NumberMatcher, userValue = true, matchValue = emptyList()))
+            assertTrue(ExistsMatcher.matches(valueMatcher = NumberMatcher, userValue = v("1.0.0"), matchValue = emptyList()))
+
+            assertTrue(ExistsMatcher.matches(valueMatcher = BooleanMatcher, userValue = "abc", matchValue = emptyList()))
+            assertTrue(ExistsMatcher.matches(valueMatcher = BooleanMatcher, userValue = 320, matchValue = emptyList()))
+            assertTrue(ExistsMatcher.matches(valueMatcher = BooleanMatcher, userValue = true, matchValue = emptyList()))
+            assertTrue(ExistsMatcher.matches(valueMatcher = BooleanMatcher, userValue = v("1.0.0"), matchValue = emptyList()))
+
+            assertTrue(ExistsMatcher.matches(valueMatcher = VersionMatcher, userValue = "abc", matchValue = emptyList()))
+            assertTrue(ExistsMatcher.matches(valueMatcher = VersionMatcher, userValue = 320, matchValue = emptyList()))
+            assertTrue(ExistsMatcher.matches(valueMatcher = VersionMatcher, userValue = true, matchValue = emptyList()))
+            assertTrue(ExistsMatcher.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValue = emptyList()))
         }
     }
 

--- a/hackle-sdk-core/src/test/kotlin/io/hackle/sdk/core/evaluation/match/OperatorMatcherTest.kt
+++ b/hackle-sdk-core/src/test/kotlin/io/hackle/sdk/core/evaluation/match/OperatorMatcherTest.kt
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 
 internal class OperatorMatcherTest {
-
     @Nested
     inner class InMatcherTest {
 
@@ -16,32 +15,33 @@ internal class OperatorMatcherTest {
 
         @Test
         fun `string`() {
-            assertTrue(sut.matches(userValue = "abc", matchValue = "abc"))
-            assertFalse(sut.matches(userValue = "abc", matchValue = "abc1"))
+            assertTrue(sut.matches(valueMatcher = StringMatcher, userValue = "abc", matchValue = listOf("abc")))
+            assertTrue(sut.matches(valueMatcher = StringMatcher, userValue = "abc", matchValue = listOf("abc", "def")))
+            assertFalse(sut.matches(valueMatcher = StringMatcher, userValue = "abc", matchValue = listOf("abc1")))
         }
 
         @Test
         fun `number`() {
-            assertTrue(sut.matches(userValue = 320, matchValue = 320))
-            assertTrue(sut.matches(userValue = 320.0, matchValue = 320))
-            assertTrue(sut.matches(userValue = 320.1, matchValue = BigDecimal("320.10")))
-            assertTrue(sut.matches(userValue = BigDecimal("320.00"), matchValue = 320))
-            assertFalse(sut.matches(userValue = BigDecimal("320.01"), matchValue = 320))
-            assertFalse(sut.matches(userValue = 321, matchValue = 320))
+            assertTrue(sut.matches(valueMatcher = NumberMatcher, userValue = 320, matchValue = listOf(320)))
+            assertTrue(sut.matches(valueMatcher = NumberMatcher, userValue = 320.0, matchValue = listOf(320)))
+            assertTrue(sut.matches(valueMatcher = NumberMatcher, userValue = 320.1, matchValue = listOf(BigDecimal("320.10"))))
+            assertTrue(sut.matches(valueMatcher = NumberMatcher, userValue = BigDecimal("320.00"), matchValue = listOf(320)))
+            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = BigDecimal("320.01"), matchValue = listOf(320)))
+            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = 321, matchValue = listOf(320)))
         }
 
         @Test
         fun `boolean`() {
-            assertTrue(sut.matches(userValue = true, matchValue = true))
-            assertTrue(sut.matches(userValue = false, matchValue = false))
-            assertFalse(sut.matches(userValue = true, matchValue = false))
-            assertFalse(sut.matches(userValue = false, matchValue = true))
+            assertTrue(sut.matches(valueMatcher = BooleanMatcher, userValue = true, matchValue = listOf(true)))
+            assertTrue(sut.matches(valueMatcher = BooleanMatcher, userValue = false, matchValue = listOf(false)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = true, matchValue = listOf(false)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = false, matchValue = listOf(true)))
         }
 
         @Test
         fun `version`() {
-            assertTrue(sut.matches(userValue = v("1.0.0"), matchValue = v("1.0.0")))
-            assertFalse(sut.matches(userValue = v("1.0.0"), matchValue = v("2.0.0")))
+            assertTrue(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValue = listOf(v("1.0.0"))))
+            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValue = listOf(v("2.0.0"))))
         }
     }
 
@@ -52,33 +52,33 @@ internal class OperatorMatcherTest {
 
         @Test
         fun `string`() {
-            assertTrue(sut.matches(userValue = "abc", matchValue = "abc"))
-            assertTrue(sut.matches(userValue = "abc", matchValue = "a"))
-            assertTrue(sut.matches(userValue = "abc", matchValue = "b"))
-            assertTrue(sut.matches(userValue = "abc", matchValue = "c"))
-            assertTrue(sut.matches(userValue = "abc", matchValue = "ab"))
-            assertFalse(sut.matches(userValue = "abc", matchValue = "ac"))
-            assertFalse(sut.matches(userValue = "a", matchValue = "ab"))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "abc", matchValue = listOf("abc")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "abc", matchValue = listOf("a")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "abc", matchValue = listOf("b")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "abc", matchValue = listOf("c")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "abc", matchValue = listOf("ab")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "abc", matchValue = listOf("ac")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "a", matchValue = listOf("ab")))
         }
 
         @Test
         fun `number`() {
-            assertFalse(sut.matches(userValue = 1, matchValue = 1))
-            assertFalse(sut.matches(userValue = 11, matchValue = 1))
+            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = 1, matchValue = listOf(1)))
+            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = 11, matchValue = listOf(1)))
         }
 
         @Test
         fun `boolean`() {
-            assertFalse(sut.matches(userValue = true, matchValue = true))
-            assertFalse(sut.matches(userValue = false, matchValue = false))
-            assertFalse(sut.matches(userValue = true, matchValue = false))
-            assertFalse(sut.matches(userValue = false, matchValue = true))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = true, matchValue = listOf(true)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = false, matchValue = listOf(false)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = true, matchValue = listOf(false)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = false, matchValue = listOf(true)))
         }
 
         @Test
         fun `version`() {
-            assertFalse(sut.matches(userValue = v("1.0.0"), matchValue = v("1.0.0")))
-            assertFalse(sut.matches(userValue = v("1.0.0"), matchValue = v("2.0.0")))
+            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValue = listOf(v("1.0.0"))))
+            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValue = listOf(v("2.0.0"))))
         }
     }
 
@@ -89,30 +89,30 @@ internal class OperatorMatcherTest {
 
         @Test
         fun `string`() {
-            assertTrue(sut.matches(userValue = "abc", matchValue = "abc"))
-            assertTrue(sut.matches(userValue = "abc", matchValue = "a"))
-            assertFalse(sut.matches(userValue = "abc", matchValue = "b"))
-            assertFalse(sut.matches(userValue = "a", matchValue = "ab"))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "abc", matchValue = listOf("abc")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "abc", matchValue = listOf("a")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "abc", matchValue = listOf("b")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "a", matchValue = listOf("ab")))
         }
 
         @Test
         fun `number`() {
-            assertFalse(sut.matches(userValue = 1, matchValue = 1))
-            assertFalse(sut.matches(userValue = 11, matchValue = 1))
+            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = 1, matchValue = listOf(1)))
+            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = 11, matchValue = listOf(1)))
         }
 
         @Test
         fun `boolean`() {
-            assertFalse(sut.matches(userValue = true, matchValue = true))
-            assertFalse(sut.matches(userValue = false, matchValue = false))
-            assertFalse(sut.matches(userValue = true, matchValue = false))
-            assertFalse(sut.matches(userValue = false, matchValue = true))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = true, matchValue = listOf(true)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = false, matchValue = listOf(false)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = true, matchValue = listOf(false)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = false, matchValue = listOf(true)))
         }
 
         @Test
         fun `version`() {
-            assertFalse(sut.matches(userValue = v("1.0.0"), matchValue = v("1.0.0")))
-            assertFalse(sut.matches(userValue = v("1.0.0"), matchValue = v("2.0.0")))
+            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValue = listOf(v("1.0.0"))))
+            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValue = listOf(v("2.0.0"))))
         }
     }
 
@@ -123,31 +123,31 @@ internal class OperatorMatcherTest {
 
         @Test
         fun `string`() {
-            assertTrue(sut.matches(userValue = "abc", matchValue = "abc"))
-            assertFalse(sut.matches(userValue = "abc", matchValue = "a"))
-            assertTrue(sut.matches(userValue = "abc", matchValue = "c"))
-            assertTrue(sut.matches(userValue = "abc", matchValue = "bc"))
-            assertFalse(sut.matches(userValue = "a", matchValue = "ab"))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "abc", matchValue = listOf("abc")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "abc", matchValue = listOf("a")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "abc", matchValue = listOf("c")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "abc", matchValue = listOf("bc")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "a", matchValue = listOf("ab")))
         }
 
         @Test
         fun `number`() {
-            assertFalse(sut.matches(userValue = 1, matchValue = 1))
-            assertFalse(sut.matches(userValue = 11, matchValue = 1))
+            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = 1, matchValue = listOf(1)))
+            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = 11, matchValue = listOf(1)))
         }
 
         @Test
         fun `boolean`() {
-            assertFalse(sut.matches(userValue = true, matchValue = true))
-            assertFalse(sut.matches(userValue = false, matchValue = false))
-            assertFalse(sut.matches(userValue = true, matchValue = false))
-            assertFalse(sut.matches(userValue = false, matchValue = true))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = true, matchValue = listOf(true)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = false, matchValue = listOf(false)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = true, matchValue = listOf(false)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = false, matchValue = listOf(true)))
         }
 
         @Test
         fun `version`() {
-            assertFalse(sut.matches(userValue = v("1.0.0"), matchValue = v("1.0.0")))
-            assertFalse(sut.matches(userValue = v("1.0.0"), matchValue = v("2.0.0")))
+            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValue = listOf(v("1.0.0"))))
+            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValue = listOf(v("2.0.0"))))
         }
     }
 
@@ -158,46 +158,46 @@ internal class OperatorMatcherTest {
 
         @Test
         fun `string`() {
-            assertFalse(sut.matches(userValue = "41", matchValue = "42"))
-            assertFalse(sut.matches(userValue = "42", matchValue = "42"))
-            assertTrue(sut.matches(userValue = "43", matchValue = "42"))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "41", matchValue = listOf("42")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "42", matchValue = listOf("42")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "43", matchValue = listOf("42")))
 
-            assertFalse(sut.matches(userValue = "20230114", matchValue = "20230115"))
-            assertFalse(sut.matches(userValue = "20230115", matchValue = "20230115"))
-            assertTrue(sut.matches(userValue = "20230116", matchValue = "20230115"))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "20230114", matchValue = listOf("20230115")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "20230115", matchValue = listOf("20230115")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "20230116", matchValue = listOf("20230115")))
 
-            assertFalse(sut.matches(userValue = "2023-01-14", matchValue = "2023-01-15"))
-            assertFalse(sut.matches(userValue = "2023-01-15", matchValue = "2023-01-15"))
-            assertTrue(sut.matches(userValue = "2023-01-16", matchValue = "2023-01-15"))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "2023-01-14", matchValue = listOf("2023-01-15")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "2023-01-15", matchValue = listOf("2023-01-15")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "2023-01-16", matchValue = listOf("2023-01-15")))
 
-            assertFalse(sut.matches(userValue = "a", matchValue = "a"))
-            assertTrue(sut.matches(userValue = "a", matchValue = "A"))
-            assertFalse(sut.matches(userValue = "A", matchValue = "a"))
-            assertTrue(sut.matches(userValue = "aa", matchValue = "a"))
-            assertFalse(sut.matches(userValue = "a", matchValue = "aa"))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "a", matchValue = listOf("a")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "a", matchValue = listOf("A")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "A", matchValue = listOf("a")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "aa", matchValue = listOf("a")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "a", matchValue = listOf("aa")))
         }
 
         @Test
         fun `number`() {
-            assertTrue(sut.matches(userValue = 1.001, matchValue = 1))
-            assertTrue(sut.matches(userValue = 2, matchValue = 1))
-            assertFalse(sut.matches(userValue = 1, matchValue = 1))
-            assertFalse(sut.matches(userValue = 0.999, matchValue = 1))
+            assertTrue(sut.matches(valueMatcher = NumberMatcher, userValue = 1.001, matchValue = listOf(1)))
+            assertTrue(sut.matches(valueMatcher = NumberMatcher, userValue = 2, matchValue = listOf(1)))
+            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = 1, matchValue = listOf(1)))
+            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = 0.999, matchValue = listOf(1)))
         }
 
         @Test
         fun `boolean`() {
-            assertFalse(sut.matches(userValue = true, matchValue = true))
-            assertFalse(sut.matches(userValue = false, matchValue = false))
-            assertFalse(sut.matches(userValue = true, matchValue = false))
-            assertFalse(sut.matches(userValue = false, matchValue = true))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = true, matchValue = listOf(true)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = false, matchValue = listOf(false)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = true, matchValue = listOf(false)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = false, matchValue = listOf(true)))
         }
 
         @Test
         fun `version`() {
-            assertFalse(sut.matches(userValue = v("1.0.0"), matchValue = v("1.0.0")))
-            assertFalse(sut.matches(userValue = v("1.0.0"), matchValue = v("2.0.0")))
-            assertTrue(sut.matches(userValue = v("2.0.0"), matchValue = v("1.0.0")))
+            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValue = listOf(v("1.0.0"))))
+            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValue = listOf(v("2.0.0"))))
+            assertTrue(sut.matches(valueMatcher = VersionMatcher, userValue = v("2.0.0"), matchValue = listOf(v("1.0.0"))))
         }
     }
 
@@ -208,46 +208,46 @@ internal class OperatorMatcherTest {
 
         @Test
         fun `string`() {
-            assertFalse(sut.matches(userValue = "41", matchValue = "42"))
-            assertTrue(sut.matches(userValue = "42", matchValue = "42"))
-            assertTrue(sut.matches(userValue = "43", matchValue = "42"))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "41", matchValue = listOf("42")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "42", matchValue = listOf("42")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "43", matchValue = listOf("42")))
 
-            assertFalse(sut.matches(userValue = "20230114", matchValue = "20230115"))
-            assertTrue(sut.matches(userValue = "20230115", matchValue = "20230115"))
-            assertTrue(sut.matches(userValue = "20230116", matchValue = "20230115"))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "20230114", matchValue = listOf("20230115")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "20230115", matchValue = listOf("20230115")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "20230116", matchValue = listOf("20230115")))
 
-            assertFalse(sut.matches(userValue = "2023-01-14", matchValue = "2023-01-15"))
-            assertTrue(sut.matches(userValue = "2023-01-15", matchValue = "2023-01-15"))
-            assertTrue(sut.matches(userValue = "2023-01-16", matchValue = "2023-01-15"))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "2023-01-14", matchValue = listOf("2023-01-15")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "2023-01-15", matchValue = listOf("2023-01-15")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "2023-01-16", matchValue = listOf("2023-01-15")))
 
-            assertTrue(sut.matches(userValue = "a", matchValue = "a"))
-            assertTrue(sut.matches(userValue = "a", matchValue = "A"))
-            assertFalse(sut.matches(userValue = "A", matchValue = "a"))
-            assertTrue(sut.matches(userValue = "aa", matchValue = "a"))
-            assertFalse(sut.matches(userValue = "a", matchValue = "aa"))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "a", matchValue = listOf("a")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "a", matchValue = listOf("A")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "A", matchValue = listOf("a")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "aa", matchValue = listOf("a")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "a", matchValue = listOf("aa")))
         }
 
         @Test
         fun `number`() {
-            assertTrue(sut.matches(userValue = 1.001, matchValue = 1))
-            assertTrue(sut.matches(userValue = 2, matchValue = 1))
-            assertTrue(sut.matches(userValue = 1, matchValue = 1))
-            assertFalse(sut.matches(userValue = 0.999, matchValue = 1))
+            assertTrue(sut.matches(valueMatcher = NumberMatcher, userValue = 1.001, matchValue = listOf(1)))
+            assertTrue(sut.matches(valueMatcher = NumberMatcher, userValue = 2, matchValue = listOf(1)))
+            assertTrue(sut.matches(valueMatcher = NumberMatcher, userValue = 1, matchValue = listOf(1)))
+            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = 0.999, matchValue = listOf(1)))
         }
 
         @Test
         fun `boolean`() {
-            assertFalse(sut.matches(userValue = true, matchValue = true))
-            assertFalse(sut.matches(userValue = false, matchValue = false))
-            assertFalse(sut.matches(userValue = true, matchValue = false))
-            assertFalse(sut.matches(userValue = false, matchValue = true))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = true, matchValue = listOf(true)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = false, matchValue = listOf(false)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = true, matchValue = listOf(false)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = false, matchValue = listOf(true)))
         }
 
         @Test
         fun `version`() {
-            assertTrue(sut.matches(userValue = v("1.0.0"), matchValue = v("1.0.0")))
-            assertFalse(sut.matches(userValue = v("1.0.0"), matchValue = v("2.0.0")))
-            assertTrue(sut.matches(userValue = v("2.0.0"), matchValue = v("1.0.0")))
+            assertTrue(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValue = listOf(v("1.0.0"))))
+            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValue = listOf(v("2.0.0"))))
+            assertTrue(sut.matches(valueMatcher = VersionMatcher, userValue = v("2.0.0"), matchValue = listOf(v("1.0.0"))))
         }
     }
 
@@ -258,46 +258,46 @@ internal class OperatorMatcherTest {
 
         @Test
         fun `string`() {
-            assertTrue(sut.matches(userValue = "41", matchValue = "42"))
-            assertFalse(sut.matches(userValue = "42", matchValue = "42"))
-            assertFalse(sut.matches(userValue = "43", matchValue = "42"))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "41", matchValue = listOf("42")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "42", matchValue = listOf("42")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "43", matchValue = listOf("42")))
 
-            assertTrue(sut.matches(userValue = "20230114", matchValue = "20230115"))
-            assertFalse(sut.matches(userValue = "20230115", matchValue = "20230115"))
-            assertFalse(sut.matches(userValue = "20230116", matchValue = "20230115"))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "20230114", matchValue = listOf("20230115")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "20230115", matchValue = listOf("20230115")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "20230116", matchValue = listOf("20230115")))
 
-            assertTrue(sut.matches(userValue = "2023-01-14", matchValue = "2023-01-15"))
-            assertFalse(sut.matches(userValue = "2023-01-15", matchValue = "2023-01-15"))
-            assertFalse(sut.matches(userValue = "2023-01-16", matchValue = "2023-01-15"))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "2023-01-14", matchValue = listOf("2023-01-15")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "2023-01-15", matchValue = listOf("2023-01-15")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "2023-01-16", matchValue = listOf("2023-01-15")))
 
-            assertFalse(sut.matches(userValue = "a", matchValue = "a"))
-            assertFalse(sut.matches(userValue = "a", matchValue = "A"))
-            assertTrue(sut.matches(userValue = "A", matchValue = "a"))
-            assertFalse(sut.matches(userValue = "aa", matchValue = "a"))
-            assertTrue(sut.matches(userValue = "a", matchValue = "aa"))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "a", matchValue = listOf("a")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "a", matchValue = listOf("A")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "A", matchValue = listOf("a")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "aa", matchValue = listOf("a")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "a", matchValue = listOf("aa")))
         }
 
         @Test
         fun `number`() {
-            assertFalse(sut.matches(userValue = 1.001, matchValue = 1))
-            assertFalse(sut.matches(userValue = 2, matchValue = 1))
-            assertFalse(sut.matches(userValue = 1, matchValue = 1))
-            assertTrue(sut.matches(userValue = 0.999, matchValue = 1))
+            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = 1.001, matchValue = listOf(1)))
+            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = 2, matchValue = listOf(1)))
+            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = 1, matchValue = listOf(1)))
+            assertTrue(sut.matches(valueMatcher = NumberMatcher, userValue = 0.999, matchValue = listOf(1)))
         }
 
         @Test
         fun `boolean`() {
-            assertFalse(sut.matches(userValue = true, matchValue = true))
-            assertFalse(sut.matches(userValue = false, matchValue = false))
-            assertFalse(sut.matches(userValue = true, matchValue = false))
-            assertFalse(sut.matches(userValue = false, matchValue = true))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = true, matchValue = listOf(true)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = false, matchValue = listOf(false)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = true, matchValue = listOf(false)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = false, matchValue = listOf(true)))
         }
 
         @Test
         fun `version`() {
-            assertFalse(sut.matches(userValue = v("1.0.0"), matchValue = v("1.0.0")))
-            assertTrue(sut.matches(userValue = v("1.0.0"), matchValue = v("2.0.0")))
-            assertFalse(sut.matches(userValue = v("2.0.0"), matchValue = v("1.0.0")))
+            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValue = listOf(v("1.0.0"))))
+            assertTrue(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValue = listOf(v("2.0.0"))))
+            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = v("2.0.0"), matchValue = listOf(v("1.0.0"))))
         }
     }
 
@@ -308,46 +308,46 @@ internal class OperatorMatcherTest {
 
         @Test
         fun `string`() {
-            assertTrue(sut.matches(userValue = "41", matchValue = "42"))
-            assertTrue(sut.matches(userValue = "42", matchValue = "42"))
-            assertFalse(sut.matches(userValue = "43", matchValue = "42"))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "41", matchValue = listOf("42")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "42", matchValue = listOf("42")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "43", matchValue = listOf("42")))
 
-            assertTrue(sut.matches(userValue = "20230114", matchValue = "20230115"))
-            assertTrue(sut.matches(userValue = "20230115", matchValue = "20230115"))
-            assertFalse(sut.matches(userValue = "20230116", matchValue = "20230115"))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "20230114", matchValue = listOf("20230115")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "20230115", matchValue = listOf("20230115")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "20230116", matchValue = listOf("20230115")))
 
-            assertTrue(sut.matches(userValue = "2023-01-14", matchValue = "2023-01-15"))
-            assertTrue(sut.matches(userValue = "2023-01-15", matchValue = "2023-01-15"))
-            assertFalse(sut.matches(userValue = "2023-01-16", matchValue = "2023-01-15"))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "2023-01-14", matchValue = listOf("2023-01-15")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "2023-01-15", matchValue = listOf("2023-01-15")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "2023-01-16", matchValue = listOf("2023-01-15")))
 
-            assertTrue(sut.matches(userValue = "a", matchValue = "a"))
-            assertFalse(sut.matches(userValue = "a", matchValue = "A"))
-            assertTrue(sut.matches(userValue = "A", matchValue = "a"))
-            assertFalse(sut.matches(userValue = "aa", matchValue = "a"))
-            assertTrue(sut.matches(userValue = "a", matchValue = "aa"))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "a", matchValue = listOf("a")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "a", matchValue = listOf("A")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "A", matchValue = listOf("a")))
+            assertFalse(sut.matches(valueMatcher  = StringMatcher, userValue = "aa", matchValue = listOf("a")))
+            assertTrue(sut.matches(valueMatcher  = StringMatcher, userValue = "a", matchValue = listOf("aa")))
         }
 
         @Test
         fun `number`() {
-            assertFalse(sut.matches(userValue = 1.001, matchValue = 1))
-            assertFalse(sut.matches(userValue = 2, matchValue = 1))
-            assertTrue(sut.matches(userValue = 1, matchValue = 1))
-            assertTrue(sut.matches(userValue = 0.999, matchValue = 1))
+            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = 1.001, matchValue = listOf(1)))
+            assertFalse(sut.matches(valueMatcher = NumberMatcher, userValue = 2, matchValue = listOf(1)))
+            assertTrue(sut.matches(valueMatcher = NumberMatcher, userValue = 1, matchValue = listOf(1)))
+            assertTrue(sut.matches(valueMatcher = NumberMatcher, userValue = 0.999, matchValue = listOf(1)))
         }
 
         @Test
         fun `boolean`() {
-            assertFalse(sut.matches(userValue = true, matchValue = true))
-            assertFalse(sut.matches(userValue = false, matchValue = false))
-            assertFalse(sut.matches(userValue = true, matchValue = false))
-            assertFalse(sut.matches(userValue = false, matchValue = true))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = true, matchValue = listOf(true)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = false, matchValue = listOf(false)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = true, matchValue = listOf(false)))
+            assertFalse(sut.matches(valueMatcher = BooleanMatcher, userValue = false, matchValue = listOf(true)))
         }
 
         @Test
         fun `version`() {
-            assertTrue(sut.matches(userValue = v("1.0.0"), matchValue = v("1.0.0")))
-            assertTrue(sut.matches(userValue = v("1.0.0"), matchValue = v("2.0.0")))
-            assertFalse(sut.matches(userValue = v("2.0.0"), matchValue = v("1.0.0")))
+            assertTrue(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValue = listOf(v("1.0.0"))))
+            assertTrue(sut.matches(valueMatcher = VersionMatcher, userValue = v("1.0.0"), matchValue = listOf(v("2.0.0"))))
+            assertFalse(sut.matches(valueMatcher = VersionMatcher, userValue = v("2.0.0"), matchValue = listOf(v("1.0.0"))))
         }
     }
 

--- a/hackle-sdk-core/src/test/kotlin/io/hackle/sdk/core/evaluation/match/UserConditionMatcherTest.kt
+++ b/hackle-sdk-core/src/test/kotlin/io/hackle/sdk/core/evaluation/match/UserConditionMatcherTest.kt
@@ -29,9 +29,11 @@ internal class UserConditionMatcherTest {
     private lateinit var sut: UserConditionMatcher
 
     @Test
-    fun `Key 에 해당하는 UserValue 가 없으면 match false`() {
+    fun `Key 에 해당하는 UserValue 가 없어도 operatorMatcher 결과로 매칭한다`() {
         // given
         every { userValueResolver.resolveOrNull(any(), any()) } returns null
+        every { valueOperatorMatcher.matches(any(), any()) } returns false
+
         val condition = condition {
             USER_PROPERTY("grade")
             IN("gold")
@@ -65,7 +67,7 @@ internal class UserConditionMatcherTest {
         // then
         assertTrue(actual)
         verify(exactly = 1) {
-            valueOperatorMatcher.matches("test_user_value", condition.match)
+            valueOperatorMatcher.matches(userValue, condition.match)
         }
     }
 }

--- a/hackle-sdk-core/src/test/kotlin/io/hackle/sdk/core/evaluation/match/ValueMatcherTest.kt
+++ b/hackle-sdk-core/src/test/kotlin/io/hackle/sdk/core/evaluation/match/ValueMatcherTest.kt
@@ -137,6 +137,24 @@ internal class ValueMatcherTest {
         }
 
         @Test
+        fun `숫자형 범위 체크`() {
+            assertTrue(NumberMatcher.inMatch(0, 0))
+            assertTrue(NumberMatcher.inMatch(0.0, 0.0))
+
+            assertTrue(NumberMatcher.inMatch(Int.MAX_VALUE, Int.MAX_VALUE))
+            assertTrue(NumberMatcher.inMatch(Int.MIN_VALUE, Int.MIN_VALUE))
+
+            assertTrue(NumberMatcher.inMatch(Double.MAX_VALUE, Double.MAX_VALUE))
+            assertTrue(NumberMatcher.inMatch(Double.MIN_VALUE, Double.MIN_VALUE))
+
+            assertTrue(NumberMatcher.inMatch(Long.MAX_VALUE, Long.MAX_VALUE))
+            assertTrue(NumberMatcher.inMatch(Long.MIN_VALUE, Long.MIN_VALUE))
+
+            assertTrue(NumberMatcher.inMatch(Float.MAX_VALUE, Float.MAX_VALUE))
+            assertTrue(NumberMatcher.inMatch(Float.MIN_VALUE, Float.MIN_VALUE))
+        }
+
+        @Test
         fun `target이 숫자형이 아니면 항상 false`() {
             assertFalse(NumberMatcher.inMatch(42, "string"))
             assertFalse(NumberMatcher.containsMatch(42, "string"))

--- a/hackle-sdk-core/src/test/kotlin/io/hackle/sdk/core/evaluation/match/ValueMatcherTest.kt
+++ b/hackle-sdk-core/src/test/kotlin/io/hackle/sdk/core/evaluation/match/ValueMatcherTest.kt
@@ -22,20 +22,6 @@ internal class ValueMatcherTest {
             assertTrue(StringMatcher.lessThanMatch("41", "42"))
             assertTrue(StringMatcher.lessThanOrEqualToMatch("42", "42"))
             assertTrue(StringMatcher.lessThanOrEqualToMatch("41", "42"))
-            assertTrue(StringMatcher.existsMatch("42"))
-        }
-
-        @Test
-        fun `uservalue가 null이면 항상 false`() {
-            assertFalse(StringMatcher.inMatch(null, "42"))
-            assertFalse(StringMatcher.containsMatch(null, "42"))
-            assertFalse(StringMatcher.startsWithMatch(null, "42"))
-            assertFalse(StringMatcher.endsWithMatch(null, "42"))
-            assertFalse(StringMatcher.greaterThanMatch(null, "42"))
-            assertFalse(StringMatcher.greaterThanOrEqualToMatch(null, "42"))
-            assertFalse(StringMatcher.lessThanMatch(null, "42"))
-            assertFalse(StringMatcher.lessThanOrEqualToMatch(null, "42"))
-            assertFalse(StringMatcher.existsMatch(null))
         }
 
         @Test
@@ -135,21 +121,6 @@ internal class ValueMatcherTest {
             assertTrue(NumberMatcher.lessThanOrEqualToMatch(42, 42L))
             assertTrue(NumberMatcher.lessThanOrEqualToMatch(0, 0.0))
             assertTrue(NumberMatcher.lessThanOrEqualToMatch(0.0, 0))
-
-            assertTrue(NumberMatcher.existsMatch(42))
-        }
-
-        @Test
-        fun `userValue가 null이면 항상 false`() {
-            assertFalse(NumberMatcher.inMatch(null, 42))
-            assertFalse(NumberMatcher.containsMatch(null, 42))
-            assertFalse(NumberMatcher.startsWithMatch(null, 42))
-            assertFalse(NumberMatcher.endsWithMatch(null, 42))
-            assertFalse(NumberMatcher.greaterThanMatch(null, 42))
-            assertFalse(NumberMatcher.greaterThanOrEqualToMatch(null, 42))
-            assertFalse(NumberMatcher.lessThanMatch(null, 42))
-            assertFalse(NumberMatcher.lessThanOrEqualToMatch(null, 42))
-            assertFalse(NumberMatcher.existsMatch(null))
         }
 
         @Test
@@ -232,23 +203,6 @@ internal class ValueMatcherTest {
             assertFalse(BooleanMatcher.inMatch(1L, "true"))
             assertFalse(BooleanMatcher.inMatch("string", true))
             assertFalse(BooleanMatcher.inMatch(true, "string"))
-
-            assertTrue(BooleanMatcher.existsMatch(true))
-            assertTrue(BooleanMatcher.existsMatch(false))
-            assertFalse(BooleanMatcher.existsMatch(null))
-        }
-
-        @Test
-        fun `userValue가 null이면 항상 false`() {
-            assertFalse(BooleanMatcher.inMatch(null, true))
-            assertFalse(BooleanMatcher.containsMatch(null, true))
-            assertFalse(BooleanMatcher.startsWithMatch(null, true))
-            assertFalse(BooleanMatcher.endsWithMatch(null, true))
-            assertFalse(BooleanMatcher.greaterThanMatch(null, true))
-            assertFalse(BooleanMatcher.greaterThanOrEqualToMatch(null, true))
-            assertFalse(BooleanMatcher.lessThanMatch(null, true))
-            assertFalse(BooleanMatcher.lessThanOrEqualToMatch(null, true))
-            assertFalse(BooleanMatcher.existsMatch(null))
         }
 
         @Test
@@ -261,8 +215,6 @@ internal class ValueMatcherTest {
             assertFalse(BooleanMatcher.lessThanMatch(true, true))
             assertFalse(BooleanMatcher.lessThanOrEqualToMatch(true, true))
         }
-
-
     }
 
     @Nested
@@ -278,7 +230,6 @@ internal class ValueMatcherTest {
             assertTrue(VersionMatcher.lessThanMatch("0.0.9", "1.0.0"))
             assertTrue(VersionMatcher.lessThanOrEqualToMatch("1.0.0", "1.0.0"))
             assertTrue(VersionMatcher.lessThanOrEqualToMatch("1.0.0", "1.0.1"))
-            assertTrue(VersionMatcher.existsMatch("1.0.0"))
         }
 
         @Test
@@ -295,25 +246,10 @@ internal class ValueMatcherTest {
         }
 
         @Test
-        fun `userValue가 null이면 항상 false`() {
-            assertFalse(VersionMatcher.inMatch(null, "1.0.0"))
-            assertFalse(VersionMatcher.containsMatch(null, "1.0.0"))
-            assertFalse(VersionMatcher.startsWithMatch(null, "1.0.0"))
-            assertFalse(VersionMatcher.endsWithMatch(null, "1.0.0"))
-            assertFalse(VersionMatcher.greaterThanMatch(null, "1.0.0"))
-            assertFalse(VersionMatcher.greaterThanOrEqualToMatch(null, "1.0.0"))
-            assertFalse(VersionMatcher.lessThanMatch(null, "1.0.0"))
-            assertFalse(VersionMatcher.lessThanOrEqualToMatch(null, "1.0.0"))
-            assertFalse(VersionMatcher.existsMatch(null))
-        }
-
-        @Test
         fun `지원하지 않는 연산자`() {
             assertFalse(VersionMatcher.containsMatch("1.0.0", "1.0.0"))
             assertFalse(VersionMatcher.startsWithMatch("1.0.0", "1.0.0"))
             assertFalse(VersionMatcher.endsWithMatch("1.0.0", "1.0.0"))
-
         }
     }
-
 }

--- a/hackle-sdk-core/src/test/kotlin/io/hackle/sdk/core/evaluation/match/ValueMatcherTest.kt
+++ b/hackle-sdk-core/src/test/kotlin/io/hackle/sdk/core/evaluation/match/ValueMatcherTest.kt
@@ -39,6 +39,19 @@ internal class ValueMatcherTest {
         }
 
         @Test
+        fun `target이 자료형이 아니면 항상 false`() {
+            class tmp {}
+            assertFalse(StringMatcher.inMatch("42", tmp()))
+            assertFalse(StringMatcher.containsMatch("42", tmp()))
+            assertFalse(StringMatcher.startsWithMatch("42", tmp()))
+            assertFalse(StringMatcher.endsWithMatch("42", tmp()))
+            assertFalse(StringMatcher.greaterThanMatch("42", tmp()))
+            assertFalse(StringMatcher.greaterThanOrEqualToMatch("42", tmp()))
+            assertFalse(StringMatcher.lessThanMatch("42", tmp()))
+            assertFalse(StringMatcher.lessThanOrEqualToMatch("42", tmp()))
+        }
+
+        @Test
         fun `number 타입이면 캐스팅 후 match`() {
             assertTrue(StringMatcher.inMatch("42", 42))
             assertTrue(StringMatcher.inMatch(42, "42"))
@@ -137,6 +150,18 @@ internal class ValueMatcherTest {
             assertFalse(NumberMatcher.lessThanMatch(null, 42))
             assertFalse(NumberMatcher.lessThanOrEqualToMatch(null, 42))
             assertFalse(NumberMatcher.existsMatch(null))
+        }
+
+        @Test
+        fun `target이 숫자형이 아니면 항상 false`() {
+            assertFalse(NumberMatcher.inMatch(42, "string"))
+            assertFalse(NumberMatcher.containsMatch(42, "string"))
+            assertFalse(NumberMatcher.startsWithMatch(42, false))
+            assertFalse(NumberMatcher.endsWithMatch(42, "string"))
+            assertFalse(NumberMatcher.greaterThanMatch(42, false))
+            assertFalse(NumberMatcher.greaterThanOrEqualToMatch(42, true))
+            assertFalse(NumberMatcher.lessThanMatch(42, "1.1.1"))
+            assertFalse(NumberMatcher.lessThanOrEqualToMatch(42, "string"))
         }
 
         @Test
@@ -260,6 +285,13 @@ internal class ValueMatcherTest {
         fun `Version타입이 아니면 false`() {
             assertFalse(VersionMatcher.inMatch(1, "1.0.0"))
             assertFalse(VersionMatcher.inMatch("1.0.0", 1))
+            assertFalse(VersionMatcher.containsMatch("1.0.0", true))
+            assertFalse(VersionMatcher.startsWithMatch("1.0.0", true))
+            assertFalse(VersionMatcher.endsWithMatch("1.0.0", true))
+            assertFalse(VersionMatcher.greaterThanMatch("1.0.0", true))
+            assertFalse(VersionMatcher.greaterThanOrEqualToMatch("1.0.0", true))
+            assertFalse(VersionMatcher.lessThanMatch("1.0.0", true))
+            assertFalse(VersionMatcher.lessThanOrEqualToMatch("1.0.0", true))
         }
 
         @Test

--- a/hackle-sdk-core/src/test/kotlin/io/hackle/sdk/core/evaluation/match/ValueMatcherTest.kt
+++ b/hackle-sdk-core/src/test/kotlin/io/hackle/sdk/core/evaluation/match/ValueMatcherTest.kt
@@ -1,10 +1,5 @@
 package io.hackle.sdk.core.evaluation.match
 
-import io.hackle.sdk.core.model.Version
-import io.mockk.Called
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
@@ -16,41 +11,65 @@ internal class ValueMatcherTest {
     inner class StringMatcherTest {
         @Test
         fun `string type match`() {
-            assertTrue(StringMatcher.matches(InMatcher, "42", "42"))
+            assertTrue(StringMatcher.inMatch("42", "42"))
+            assertTrue(StringMatcher.inMatch("42.42", "42.42"))
+            assertTrue(StringMatcher.containsMatch("42", "4"))
+            assertTrue(StringMatcher.startsWithMatch("42", "4"))
+            assertTrue(StringMatcher.endsWithMatch("42", "2"))
+            assertTrue(StringMatcher.greaterThanMatch("42", "41"))
+            assertTrue(StringMatcher.greaterThanOrEqualToMatch("42", "42"))
+            assertTrue(StringMatcher.greaterThanOrEqualToMatch("43", "42"))
+            assertTrue(StringMatcher.lessThanMatch("41", "42"))
+            assertTrue(StringMatcher.lessThanOrEqualToMatch("42", "42"))
+            assertTrue(StringMatcher.lessThanOrEqualToMatch("41", "42"))
+            assertTrue(StringMatcher.existsMatch("42"))
+        }
+
+        @Test
+        fun `uservalue가 null이면 항상 false`() {
+            assertFalse(StringMatcher.inMatch(null, "42"))
+            assertFalse(StringMatcher.containsMatch(null, "42"))
+            assertFalse(StringMatcher.startsWithMatch(null, "42"))
+            assertFalse(StringMatcher.endsWithMatch(null, "42"))
+            assertFalse(StringMatcher.greaterThanMatch(null, "42"))
+            assertFalse(StringMatcher.greaterThanOrEqualToMatch(null, "42"))
+            assertFalse(StringMatcher.lessThanMatch(null, "42"))
+            assertFalse(StringMatcher.lessThanOrEqualToMatch(null, "42"))
+            assertFalse(StringMatcher.existsMatch(null))
         }
 
         @Test
         fun `number 타입이면 캐스팅 후 match`() {
-            assertTrue(StringMatcher.matches(InMatcher, "42", 42))
-            assertTrue(StringMatcher.matches(InMatcher, 42, "42"))
-            assertTrue(StringMatcher.matches(InMatcher, 42, 42))
+            assertTrue(StringMatcher.inMatch("42", 42))
+            assertTrue(StringMatcher.inMatch(42, "42"))
+            assertTrue(StringMatcher.inMatch(42, 42))
 
-            assertTrue(StringMatcher.matches(InMatcher, 42.42, "42.42"))
-            assertTrue(StringMatcher.matches(InMatcher, "42.42", 42.42))
-            assertTrue(StringMatcher.matches(InMatcher, 42.42, 42.42))
+            assertTrue(StringMatcher.inMatch(42.42, "42.42"))
+            assertTrue(StringMatcher.inMatch("42.42", 42.42))
+            assertTrue(StringMatcher.inMatch(42.42, 42.42))
 
-            assertTrue(StringMatcher.matches(InMatcher, "42.0", 42.0))
-            assertTrue(StringMatcher.matches(InMatcher, 42.0, "42.0"))
-            assertTrue(StringMatcher.matches(InMatcher, 42.0, 42.0))
+            assertTrue(StringMatcher.inMatch("42.0", 42.0))
+            assertTrue(StringMatcher.inMatch(42.0, "42.0"))
+            assertTrue(StringMatcher.inMatch(42.0, 42.0))
         }
 
         @Test
         fun `boolean 타입이면 캐스팅 후 match`() {
-            assertTrue(StringMatcher.matches(InMatcher, "true", true))
-            assertTrue(StringMatcher.matches(InMatcher, true, "true"))
-            assertTrue(StringMatcher.matches(InMatcher, true, true))
-            assertTrue(StringMatcher.matches(InMatcher, "false", false))
-            assertTrue(StringMatcher.matches(InMatcher, false, "false"))
-            assertTrue(StringMatcher.matches(InMatcher, false, false))
+            assertTrue(StringMatcher.inMatch("true", true))
+            assertTrue(StringMatcher.inMatch(true, "true"))
+            assertTrue(StringMatcher.inMatch(true, true))
+            assertTrue(StringMatcher.inMatch("false", false))
+            assertTrue(StringMatcher.inMatch(false, "false"))
+            assertTrue(StringMatcher.inMatch(false, false))
 
-            assertFalse(StringMatcher.matches(InMatcher, true, "TRUE"))
-            assertFalse(StringMatcher.matches(InMatcher, false, "FALSE"))
+            assertFalse(StringMatcher.inMatch(true, "TRUE"))
+            assertFalse(StringMatcher.inMatch(false, "FALSE"))
         }
 
         @Test
         fun `지원하지 않는 타입`() {
-            assertFalse(StringMatcher.matches(InMatcher, true, "1"))
-            assertFalse(StringMatcher.matches(InMatcher, "1", true))
+            assertFalse(StringMatcher.inMatch(true, "1"))
+            assertFalse(StringMatcher.inMatch("1", true))
         }
     }
 
@@ -59,165 +78,209 @@ internal class ValueMatcherTest {
 
         @Test
         fun `number type match`() {
-            assertTrue(NumberMatcher.matches(InMatcher, 42, 42))
-            assertTrue(NumberMatcher.matches(InMatcher, 42.42, 42.42))
-            assertTrue(NumberMatcher.matches(InMatcher, 42, 42.0))
-            assertTrue(NumberMatcher.matches(InMatcher, 42.0, 42))
-            assertTrue(NumberMatcher.matches(InMatcher, 42L, 42))
-            assertTrue(NumberMatcher.matches(InMatcher, 42, 42L))
-            assertTrue(NumberMatcher.matches(InMatcher, 0, 0.0))
-            assertTrue(NumberMatcher.matches(InMatcher, 0.0, 0))
+            assertTrue(NumberMatcher.inMatch(42, 42))
+            assertTrue(NumberMatcher.inMatch(42.42, 42.42))
+            assertTrue(NumberMatcher.inMatch(42, 42.0))
+            assertTrue(NumberMatcher.inMatch(42.0, 42))
+            assertTrue(NumberMatcher.inMatch(42L, 42))
+            assertTrue(NumberMatcher.inMatch(42, 42L))
+            assertTrue(NumberMatcher.inMatch(0, 0.0))
+            assertTrue(NumberMatcher.inMatch(0.0, 0))
+
+            assertTrue(NumberMatcher.greaterThanMatch(42, 41))
+            assertTrue(NumberMatcher.greaterThanMatch(42.42, 42.41))
+            assertTrue(NumberMatcher.greaterThanMatch(42, 41.0))
+            assertTrue(NumberMatcher.greaterThanMatch(42.0, 41))
+            assertTrue(NumberMatcher.greaterThanMatch(42L, 41))
+            assertTrue(NumberMatcher.greaterThanMatch(42, 41L))
+            assertTrue(NumberMatcher.greaterThanMatch(0, -1))
+            assertTrue(NumberMatcher.greaterThanMatch(0.0, -1))
+
+            assertTrue(NumberMatcher.greaterThanOrEqualToMatch(42, 42))
+            assertTrue(NumberMatcher.greaterThanOrEqualToMatch(42.42, 42.42))
+            assertTrue(NumberMatcher.greaterThanOrEqualToMatch(42, 42.0))
+            assertTrue(NumberMatcher.greaterThanOrEqualToMatch(42.0, 42))
+            assertTrue(NumberMatcher.greaterThanOrEqualToMatch(42L, 42))
+            assertTrue(NumberMatcher.greaterThanOrEqualToMatch(42, 42L))
+            assertTrue(NumberMatcher.greaterThanOrEqualToMatch(0, 0.0))
+            assertTrue(NumberMatcher.greaterThanOrEqualToMatch(0.0, 0))
+
+            assertTrue(NumberMatcher.lessThanMatch(41, 42))
+            assertTrue(NumberMatcher.lessThanMatch(42.41, 42.42))
+            assertTrue(NumberMatcher.lessThanMatch(41, 42.0))
+            assertTrue(NumberMatcher.lessThanMatch(41.0, 42))
+            assertTrue(NumberMatcher.lessThanMatch(41L, 42))
+            assertTrue(NumberMatcher.lessThanMatch(41, 42L))
+            assertTrue(NumberMatcher.lessThanMatch(-1, 0))
+            assertTrue(NumberMatcher.lessThanMatch(-1.0, 0))
+
+            assertTrue(NumberMatcher.lessThanOrEqualToMatch(42, 42))
+            assertTrue(NumberMatcher.lessThanOrEqualToMatch(42.42, 42.42))
+            assertTrue(NumberMatcher.lessThanOrEqualToMatch(42, 42.0))
+            assertTrue(NumberMatcher.lessThanOrEqualToMatch(42.0, 42))
+            assertTrue(NumberMatcher.lessThanOrEqualToMatch(42L, 42))
+            assertTrue(NumberMatcher.lessThanOrEqualToMatch(42, 42L))
+            assertTrue(NumberMatcher.lessThanOrEqualToMatch(0, 0.0))
+            assertTrue(NumberMatcher.lessThanOrEqualToMatch(0.0, 0))
+
+            assertTrue(NumberMatcher.existsMatch(42))
+        }
+
+        @Test
+        fun `userValue가 null이면 항상 false`() {
+            assertFalse(NumberMatcher.inMatch(null, 42))
+            assertFalse(NumberMatcher.containsMatch(null, 42))
+            assertFalse(NumberMatcher.startsWithMatch(null, 42))
+            assertFalse(NumberMatcher.endsWithMatch(null, 42))
+            assertFalse(NumberMatcher.greaterThanMatch(null, 42))
+            assertFalse(NumberMatcher.greaterThanOrEqualToMatch(null, 42))
+            assertFalse(NumberMatcher.lessThanMatch(null, 42))
+            assertFalse(NumberMatcher.lessThanOrEqualToMatch(null, 42))
+            assertFalse(NumberMatcher.existsMatch(null))
         }
 
         @Test
         fun `string 타입이면 캐스팅 후 match`() {
-            assertTrue(NumberMatcher.matches(InMatcher, "42", "42"))
-            assertTrue(NumberMatcher.matches(InMatcher, "42", 42))
-            assertTrue(NumberMatcher.matches(InMatcher, 42, "42"))
+            assertTrue(NumberMatcher.inMatch("42", "42"))
+            assertTrue(NumberMatcher.inMatch("42", 42))
+            assertTrue(NumberMatcher.inMatch(42, "42"))
 
-            assertTrue(NumberMatcher.matches(InMatcher, "42.42", "42.42"))
-            assertTrue(NumberMatcher.matches(InMatcher, "42.42", 42.42))
-            assertTrue(NumberMatcher.matches(InMatcher, 42.42, "42.42"))
+            assertTrue(NumberMatcher.inMatch("42.42", "42.42"))
+            assertTrue(NumberMatcher.inMatch("42.42", 42.42))
+            assertTrue(NumberMatcher.inMatch(42.42, "42.42"))
 
-            assertTrue(NumberMatcher.matches(InMatcher, "42.0", "42.0"))
-            assertTrue(NumberMatcher.matches(InMatcher, "42.0", 42.0))
-            assertTrue(NumberMatcher.matches(InMatcher, 42.0, "42.0"))
+            assertTrue(NumberMatcher.inMatch("42.0", "42.0"))
+            assertTrue(NumberMatcher.inMatch("42.0", 42.0))
+            assertTrue(NumberMatcher.inMatch(42.0, "42.0"))
         }
 
         @Test
         fun `지원하지 않는 타입`() {
-            assertFalse(NumberMatcher.matches(InMatcher, "42a", 42))
-            assertFalse(NumberMatcher.matches(InMatcher, 0, "false"))
-            assertFalse(NumberMatcher.matches(InMatcher, 0, false))
-            assertFalse(NumberMatcher.matches(InMatcher, true, true))
+            assertFalse(NumberMatcher.inMatch("42a", 42))
+            assertFalse(NumberMatcher.inMatch(0, "false"))
+            assertFalse(NumberMatcher.inMatch(0, false))
+            assertFalse(NumberMatcher.inMatch(true, true))
+        }
+
+        @Test
+        fun `지원하지 않는 연산자`() {
+            assertFalse(NumberMatcher.containsMatch(42, 42))
+            assertFalse(NumberMatcher.startsWithMatch(42, 42))
+            assertFalse(NumberMatcher.endsWithMatch(42, 42))
         }
     }
 
     @Nested
     inner class BooleanMatcherTest {
-
         @Test
-        fun `userValue, matchValue가 Boolean타입이면 OperatorMatcher의 일치 결과로 평가한다`() {
-            // given
-            val userValue = false
-            val matchValue = false
-            val operatorMatcher = mockk<OperatorMatcher> {
-                every { matches(userValue, matchValue) } returns true
-            }
+        fun `boolean type matcher`() {
+            assertTrue(BooleanMatcher.inMatch(true, true))
+            assertTrue(BooleanMatcher.inMatch(false, false))
+            assertFalse(BooleanMatcher.inMatch(true, false))
+            assertFalse(BooleanMatcher.inMatch(false, true))
 
-            val sut = BooleanMatcher
+            assertTrue(BooleanMatcher.inMatch("true", true))
+            assertTrue(BooleanMatcher.inMatch("false", false))
+            assertTrue(BooleanMatcher.inMatch(true, "true"))
+            assertTrue(BooleanMatcher.inMatch(false, "false"))
+            assertFalse(BooleanMatcher.inMatch("true", false))
+            assertFalse(BooleanMatcher.inMatch("false", true))
 
-            // when
-            val actual = sut.matches(operatorMatcher, userValue, matchValue)
+            assertFalse(BooleanMatcher.inMatch("TRUE", true))
+            assertFalse(BooleanMatcher.inMatch("FALSE", false))
+            assertFalse(BooleanMatcher.inMatch(true, "TRUE"))
+            assertFalse(BooleanMatcher.inMatch(false, "FALSE"))
 
-            // then
-            assertTrue(actual)
+            assertFalse(BooleanMatcher.inMatch("true", 1))
+            assertFalse(BooleanMatcher.inMatch(1, "true"))
+            assertFalse(BooleanMatcher.inMatch("true", 1.0))
+            assertFalse(BooleanMatcher.inMatch(1.0, "true"))
+            assertFalse(BooleanMatcher.inMatch("true", "1"))
+            assertFalse(BooleanMatcher.inMatch("1", "true"))
+
+            assertFalse(BooleanMatcher.inMatch("false", 1))
+            assertFalse(BooleanMatcher.inMatch(1, "false"))
+            assertFalse(BooleanMatcher.inMatch("false", 1.0))
+            assertFalse(BooleanMatcher.inMatch(1.0, "false"))
+
+            assertFalse(BooleanMatcher.inMatch("true", 1L))
+            assertFalse(BooleanMatcher.inMatch(1L, "true"))
+            assertFalse(BooleanMatcher.inMatch("string", true))
+            assertFalse(BooleanMatcher.inMatch(true, "string"))
+
+            assertTrue(BooleanMatcher.existsMatch(true))
+            assertTrue(BooleanMatcher.existsMatch(false))
+            assertFalse(BooleanMatcher.existsMatch(null))
         }
 
         @Test
-        fun `userValue가 Boolean타입이 아니면 false`() {
-            // given
-            val userValue = "string"
-            val matchValue = false
-            val operatorMatcher = mockk<OperatorMatcher>()
-
-            val sut = BooleanMatcher
-
-            // when
-            val actual = sut.matches(operatorMatcher, userValue, matchValue)
-
-            // then
-            assertFalse(actual)
-            verify { operatorMatcher wasNot Called }
+        fun `userValue가 null이면 항상 false`() {
+            assertFalse(BooleanMatcher.inMatch(null, true))
+            assertFalse(BooleanMatcher.containsMatch(null, true))
+            assertFalse(BooleanMatcher.startsWithMatch(null, true))
+            assertFalse(BooleanMatcher.endsWithMatch(null, true))
+            assertFalse(BooleanMatcher.greaterThanMatch(null, true))
+            assertFalse(BooleanMatcher.greaterThanOrEqualToMatch(null, true))
+            assertFalse(BooleanMatcher.lessThanMatch(null, true))
+            assertFalse(BooleanMatcher.lessThanOrEqualToMatch(null, true))
+            assertFalse(BooleanMatcher.existsMatch(null))
         }
 
         @Test
-        fun `userValue가 Boolean타입이지만 matchValue가 Boolean타입이 아니면 false`() {
-            // given
-            val userValue = false
-            val matchValue = "string"
-            val operatorMatcher = mockk<OperatorMatcher>()
-
-            val sut = BooleanMatcher
-
-            // when
-            val actual = sut.matches(operatorMatcher, userValue, matchValue)
-
-            // then
-            assertFalse(actual)
-            verify { operatorMatcher wasNot Called }
+        fun `지원하지 않는 연산자`() {
+            assertFalse(BooleanMatcher.containsMatch(true, true))
+            assertFalse(BooleanMatcher.startsWithMatch(true, true))
+            assertFalse(BooleanMatcher.endsWithMatch(true, true))
+            assertFalse(BooleanMatcher.greaterThanMatch(true, true))
+            assertFalse(BooleanMatcher.greaterThanOrEqualToMatch(true, true))
+            assertFalse(BooleanMatcher.lessThanMatch(true, true))
+            assertFalse(BooleanMatcher.lessThanOrEqualToMatch(true, true))
         }
 
-        @Test
-        fun `userValue 혹은 matchValue가 String타입이지만 true이거나 false이면 BoolMatcher의 일치 결과로 평가한다`() {
-            assertTrue(BooleanMatcher.matches(InMatcher, "true", true))
-            assertTrue(BooleanMatcher.matches(InMatcher, "false", false))
 
-            assertTrue(BooleanMatcher.matches(InMatcher, true, "true"))
-            assertTrue(BooleanMatcher.matches(InMatcher, false, "false"))
-
-            assertFalse(BooleanMatcher.matches(InMatcher, "TRUE", true))
-            assertFalse(BooleanMatcher.matches(InMatcher, "FALSE", false))
-            assertFalse(BooleanMatcher.matches(InMatcher, true, "TRUE"))
-            assertFalse(BooleanMatcher.matches(InMatcher, false, "FALSE"))
-            assertFalse(BooleanMatcher.matches(InMatcher, "false", true))
-            assertFalse(BooleanMatcher.matches(InMatcher, "true", false))
-        }
     }
 
     @Nested
     inner class VersionMatcherTest {
 
         @Test
-        fun `userValue, matchValue가 Version타입이면 OperatorMatcher의 일치 결과로 평가한다`() {
-            // given
-            val userValue = "1.0.0"
-            val matchValue = "2.0.0"
-            val operatorMatcher = mockk<OperatorMatcher> {
-                every { matches(any<Version>(), any<Version>()) } returns true
-            }
-
-            val sut = VersionMatcher
-
-            // when
-            val actual = sut.matches(operatorMatcher, userValue, matchValue)
-
-            // then
-            assertTrue(actual)
+        fun `version type match`() {
+            assertTrue(VersionMatcher.inMatch("1.0.0", "1.0.0"))
+            assertFalse(VersionMatcher.inMatch("1.0.0", "2.0.0"))
+            assertTrue(VersionMatcher.greaterThanMatch("1.0.1", "1.0.0"))
+            assertTrue(VersionMatcher.greaterThanOrEqualToMatch("1.0.0", "1.0.0"))
+            assertTrue(VersionMatcher.lessThanOrEqualToMatch("1.0.0", "1.0.0"))
+            assertTrue(VersionMatcher.lessThanMatch("0.0.9", "1.0.0"))
+            assertTrue(VersionMatcher.lessThanOrEqualToMatch("1.0.0", "1.0.0"))
+            assertTrue(VersionMatcher.lessThanOrEqualToMatch("1.0.0", "1.0.1"))
+            assertTrue(VersionMatcher.existsMatch("1.0.0"))
         }
 
         @Test
-        fun `userValue가 Version타입이 아니면 false`() {
-            // given
-            val userValue = 1
-            val matchValue = "1.0.0"
-            val operatorMatcher = mockk<OperatorMatcher>()
-
-            val sut = VersionMatcher
-
-            // when
-            val actual = sut.matches(operatorMatcher, userValue, matchValue)
-
-            // then
-            assertFalse(actual)
-            verify { operatorMatcher wasNot Called }
+        fun `Version타입이 아니면 false`() {
+            assertFalse(VersionMatcher.inMatch(1, "1.0.0"))
+            assertFalse(VersionMatcher.inMatch("1.0.0", 1))
         }
 
         @Test
-        fun `userValue가 Versio타입이지만 matchValue가 Versio타입이 아니면 false`() {
-            // given
-            val userValue = "1.0.0"
-            val matchValue = 1
-            val operatorMatcher = mockk<OperatorMatcher>()
+        fun `userValue가 null이면 항상 false`() {
+            assertFalse(VersionMatcher.inMatch(null, "1.0.0"))
+            assertFalse(VersionMatcher.containsMatch(null, "1.0.0"))
+            assertFalse(VersionMatcher.startsWithMatch(null, "1.0.0"))
+            assertFalse(VersionMatcher.endsWithMatch(null, "1.0.0"))
+            assertFalse(VersionMatcher.greaterThanMatch(null, "1.0.0"))
+            assertFalse(VersionMatcher.greaterThanOrEqualToMatch(null, "1.0.0"))
+            assertFalse(VersionMatcher.lessThanMatch(null, "1.0.0"))
+            assertFalse(VersionMatcher.lessThanOrEqualToMatch(null, "1.0.0"))
+            assertFalse(VersionMatcher.existsMatch(null))
+        }
 
-            val sut = VersionMatcher
+        @Test
+        fun `지원하지 않는 연산자`() {
+            assertFalse(VersionMatcher.containsMatch("1.0.0", "1.0.0"))
+            assertFalse(VersionMatcher.startsWithMatch("1.0.0", "1.0.0"))
+            assertFalse(VersionMatcher.endsWithMatch("1.0.0", "1.0.0"))
 
-            // when
-            val actual = sut.matches(operatorMatcher, userValue, matchValue)
-
-            // then
-            assertFalse(actual)
-            verify { operatorMatcher wasNot Called }
         }
     }
 

--- a/hackle-sdk-core/src/test/kotlin/io/hackle/sdk/core/evaluation/match/ValueMatcherTest.kt
+++ b/hackle-sdk-core/src/test/kotlin/io/hackle/sdk/core/evaluation/match/ValueMatcherTest.kt
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 internal class ValueMatcherTest {
-
+    class tmp {}
     @Nested
     inner class StringMatcherTest {
         @Test
@@ -26,7 +26,6 @@ internal class ValueMatcherTest {
 
         @Test
         fun `target이 자료형이 아니면 항상 false`() {
-            class tmp {}
             assertFalse(StringMatcher.inMatch("42", tmp()))
             assertFalse(StringMatcher.containsMatch("42", tmp()))
             assertFalse(StringMatcher.startsWithMatch("42", tmp()))
@@ -35,6 +34,18 @@ internal class ValueMatcherTest {
             assertFalse(StringMatcher.greaterThanOrEqualToMatch("42", tmp()))
             assertFalse(StringMatcher.lessThanMatch("42", tmp()))
             assertFalse(StringMatcher.lessThanOrEqualToMatch("42", tmp()))
+        }
+
+        @Test
+        fun `userValue가 자료형이 아니면 항상 false`() {
+            assertFalse(StringMatcher.inMatch(tmp(), "42"))
+            assertFalse(StringMatcher.containsMatch(tmp(), "42"))
+            assertFalse(StringMatcher.startsWithMatch(tmp(), "42"))
+            assertFalse(StringMatcher.endsWithMatch(tmp(), "42"))
+            assertFalse(StringMatcher.greaterThanMatch(tmp(), "42"))
+            assertFalse(StringMatcher.greaterThanOrEqualToMatch(tmp(), "42"))
+            assertFalse(StringMatcher.lessThanMatch(tmp(), "42"))
+            assertFalse(StringMatcher.lessThanOrEqualToMatch(tmp(), "42"))
         }
 
         @Test
@@ -70,6 +81,8 @@ internal class ValueMatcherTest {
             assertFalse(StringMatcher.inMatch(true, "1"))
             assertFalse(StringMatcher.inMatch("1", true))
         }
+
+
     }
 
     @Nested
@@ -133,6 +146,18 @@ internal class ValueMatcherTest {
             assertFalse(NumberMatcher.greaterThanOrEqualToMatch(42, true))
             assertFalse(NumberMatcher.lessThanMatch(42, "1.1.1"))
             assertFalse(NumberMatcher.lessThanOrEqualToMatch(42, "string"))
+        }
+
+        @Test
+        fun `userValue가 숫자형 아니면 항상 false`() {
+            assertFalse(NumberMatcher.inMatch("string", 42))
+            assertFalse(NumberMatcher.containsMatch(false, 42))
+            assertFalse(NumberMatcher.startsWithMatch("string", 42))
+            assertFalse(NumberMatcher.endsWithMatch(false, 42))
+            assertFalse(NumberMatcher.greaterThanMatch(false, 42))
+            assertFalse(NumberMatcher.greaterThanOrEqualToMatch(true, 42))
+            assertFalse(NumberMatcher.lessThanMatch("1.1.1", 42))
+            assertFalse(NumberMatcher.lessThanOrEqualToMatch("string", 42))
         }
 
         @Test
@@ -233,7 +258,7 @@ internal class ValueMatcherTest {
         }
 
         @Test
-        fun `Version타입이 아니면 false`() {
+        fun `target이 Version타입이 아니면 false`() {
             assertFalse(VersionMatcher.inMatch(1, "1.0.0"))
             assertFalse(VersionMatcher.inMatch("1.0.0", 1))
             assertFalse(VersionMatcher.containsMatch("1.0.0", true))
@@ -243,6 +268,18 @@ internal class ValueMatcherTest {
             assertFalse(VersionMatcher.greaterThanOrEqualToMatch("1.0.0", true))
             assertFalse(VersionMatcher.lessThanMatch("1.0.0", true))
             assertFalse(VersionMatcher.lessThanOrEqualToMatch("1.0.0", true))
+        }
+
+        @Test
+        fun `userValue가 Version타입이 아니면 false`() {
+            assertFalse(VersionMatcher.inMatch(true, "1.0.0"))
+            assertFalse(VersionMatcher.containsMatch(true, "1.0.0"))
+            assertFalse(VersionMatcher.startsWithMatch(true, "1.0.0"))
+            assertFalse(VersionMatcher.endsWithMatch(true, "1.0.0"))
+            assertFalse(VersionMatcher.greaterThanMatch(true, "1.0.0"))
+            assertFalse(VersionMatcher.greaterThanOrEqualToMatch(true, "1.0.0"))
+            assertFalse(VersionMatcher.lessThanMatch(true, "1.0.0"))
+            assertFalse(VersionMatcher.lessThanOrEqualToMatch(true, "1.0.0"))
         }
 
         @Test

--- a/hackle-sdk-core/src/test/kotlin/io/hackle/sdk/core/evaluation/match/ValueOperatorMatcherFactoryTest.kt
+++ b/hackle-sdk-core/src/test/kotlin/io/hackle/sdk/core/evaluation/match/ValueOperatorMatcherFactoryTest.kt
@@ -26,5 +26,6 @@ internal class ValueOperatorMatcherFactoryTest {
         assertEquals(GreaterThanOrEqualToMatcher, ValueOperatorMatcherFactory().getOperatorMatcher(GTE))
         assertEquals(LessThanMatcher, ValueOperatorMatcherFactory().getOperatorMatcher(LT))
         assertEquals(LessThanOrEqualToMatcher, ValueOperatorMatcherFactory().getOperatorMatcher(LTE))
+        assertEquals(ExistsMatcher, ValueOperatorMatcherFactory().getOperatorMatcher(EXISTS))
     }
 }

--- a/hackle-sdk-core/src/test/kotlin/io/hackle/sdk/core/model/VersionTest.kt
+++ b/hackle-sdk-core/src/test/kotlin/io/hackle/sdk/core/model/VersionTest.kt
@@ -1,6 +1,7 @@
 package io.hackle.sdk.core.model
 
 import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -159,6 +160,21 @@ internal class VersionTest {
             expectThat(v("1.0.0-beta").toString()) isEqualTo "Version(1.0.0-beta)"
             expectThat(v("1.0.0-beta+build").toString()) isEqualTo "Version(1.0.0-beta+build)"
             expectThat(v("1.0.0+build").toString()) isEqualTo "Version(1.0.0+build)"
+        }
+
+        @Test
+        fun `hashTest`() {
+            expectThat(v("1.0.0").hashCode()) isEqualTo v("1.0.0").hashCode()
+            expectThat(v("1.0.0-beta").hashCode()) isEqualTo v("1.0.0-beta").hashCode()
+            expectThat(v("1.0.0-beta+build").hashCode()) isEqualTo v("1.0.0-beta+build").hashCode()
+            expectThat(v("1.0.0+build").hashCode()) isEqualTo v("1.0.0+build").hashCode()
+        }
+
+        @Test
+        fun `equalTest`() {
+            expectThat(v("1.0.0") == v("1.0.0"))
+            expectThat(v("1.0.0") != v("1.0.0-beta"))
+            assertFalse(v("1.0.0").equals(1))
         }
 
         private fun verifyNull(version: String) {


### PR DESCRIPTION
## 개요
- Matcher의 구조를 수정했습니다.
- EXISTS Operator를 추가했습니다.

## 작업내용
### Matcher의 구조를 수정했습니다.
#### 기존
* 순서: ValueOperatorMatcher -> ValueMatcher -> OperatorMatcher
* ValueOperatorMatcher에서 userValue가 null이면 return false
* ValueMatcher 안에서 OperatorMatcher.{type}matches 메서드 호출
#### 변경
* 순서: ValueOperatorMatcher -> OperatorMatcher -> ValueMatcher
* ValueOperatorMatcher 에서 userValue가 null이어도 OperatorMatcher까지 진입 후 연산자에 따라 처리
* OperatorMatcher에서 userValue가 null check를 수행. 그 후 ValueMatcher.{operator}match 메서드 호출

### EXISTS Operator 추가
* 존재하는/하지 않는 구분은 matchType 으로 수행합니다
* EXISTS Operator는 OperatorMatcher에서 null 체크만 합니다.