### PR TITLE
add remove all user properties

### DIFF
--- a/hackle-sdk-common/src/main/kotlin/io/hackle/sdk/common/PropertiesBuilder.kt
+++ b/hackle-sdk-common/src/main/kotlin/io/hackle/sdk/common/PropertiesBuilder.kt
@@ -42,6 +42,10 @@ class PropertiesBuilder {
             remove(key)
         }
     }
+    
+    fun clear() = apply { 
+        properties.clear()
+    }
 
     fun compute(key: String, remapping: (Any?) -> Any?) = apply {
         // Do NOT use Map.compute() to support below Android 24 & JDK 1.8

--- a/hackle-sdk-common/src/test/kotlin/io/hackle/sdk/common/PropertiesBuilderTest.kt
+++ b/hackle-sdk-common/src/test/kotlin/io/hackle/sdk/common/PropertiesBuilderTest.kt
@@ -167,6 +167,17 @@ internal class PropertiesBuilderTest {
     }
 
     @Test
+    fun clear() {
+        val properties = PropertiesBuilder()
+            .add("age", 42)
+            .add("grade", "GOLD")
+            .clear()
+            .build()
+
+        expectThat(properties).isEqualTo(emptyMap())
+    }
+
+    @Test
     fun `compute`() {
 
         val properties = PropertiesBuilder()

--- a/hackle-sdk-core/src/main/kotlin/io/hackle/sdk/core/user/HackleUser.kt
+++ b/hackle-sdk-core/src/main/kotlin/io/hackle/sdk/core/user/HackleUser.kt
@@ -51,6 +51,7 @@ data class HackleUser internal constructor(
 
         fun properties(properties: Map<String, Any>) = apply { this.properties.add(properties) }
         fun property(key: String, value: Any) = apply { this.properties.add(key, value) }
+        fun clearProperties() = apply { this.properties.clear() }
 
         fun hackleProperties(properties: Map<String, Any>) = apply { this.hackleProperties.add(properties) }
         fun hackleProperty(key: String, value: Any) = apply { this.hackleProperties.add(key, value) }

--- a/hackle-sdk-core/src/test/kotlin/io/hackle/sdk/core/user/HackleUserTest.kt
+++ b/hackle-sdk-core/src/test/kotlin/io/hackle/sdk/core/user/HackleUserTest.kt
@@ -1,6 +1,7 @@
 package io.hackle.sdk.core.user
 
 import io.hackle.sdk.core.model.Cohort
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import strikt.api.expectThat
 import strikt.assertions.isEqualTo
@@ -52,5 +53,25 @@ internal class HackleUserTest {
             )
         }
         expectThat(user.toBuilder().build()) isEqualTo user
+    }
+
+    @Test
+    fun `clearProperties should not affect identifiers, hackleProperties, cohorts, or targetEvents`() {
+        // Arrange
+        val builder = HackleUser.builder()
+        builder.identifiers(mapOf("id" to "123"))
+        builder.hackleProperty("key1", "value1")
+        builder.cohort(Cohort(0))
+        builder.properties(mapOf("key2" to "value2", "key3" to "value3"))
+
+        // Act
+        builder.clearProperties()
+        val hackleUser = builder.build()
+
+        // Assert
+        assertEquals(1, hackleUser.identifiers.size, "Identifiers should remain unchanged")
+        assertEquals(1, hackleUser.hackleProperties.size, "HackleProperties should remain unchanged")
+        assertEquals(1, hackleUser.cohorts.size, "Cohorts should remain unchanged")
+        assertEquals(0, hackleUser.properties.size, "Properties should be empty after clearProperties is called")
     }
 }


### PR DESCRIPTION
## 개요
유저 프로피터를 clear 하는 기능을 추가했습니다.

## 작업내용
### 아래 함수를 추가했습니다.
- `PropertiesBuilder.clear`
- `HackleUser.Builder.clearProperties`