### PR TITLE
add target.key.type dto

### DIFF
--- a/hackle-sdk-core/src/main/kotlin/io/hackle/sdk/core/model/TargetKeyTypeDto.kt
+++ b/hackle-sdk-core/src/main/kotlin/io/hackle/sdk/core/model/TargetKeyTypeDto.kt
@@ -1,0 +1,20 @@
+package io.hackle.sdk.core.model
+
+import io.hackle.sdk.core.internal.log.Logger
+import io.hackle.sdk.core.internal.utils.enumValueOfOrNull
+
+data class TargetKeyTypeDto(val type: Target.Key.Type) {
+    companion object {
+        fun from(rawValue: String): TargetKeyTypeDto? {
+            val type = enumValueOfOrNull<Target.Key.Type>(rawValue)
+            if (type == null) {
+                log.warn { "Unsupported type[$rawValue]. Please use the latest version of sdk." }
+                return null
+            }
+
+            return TargetKeyTypeDto(type)
+        }
+
+        private val log = Logger<TargetKeyTypeDto>()
+    }
+}

--- a/hackle-sdk-core/src/test/kotlin/io/hackle/sdk/core/model/TargetKeyTypeDtoTest.kt
+++ b/hackle-sdk-core/src/test/kotlin/io/hackle/sdk/core/model/TargetKeyTypeDtoTest.kt
@@ -1,0 +1,55 @@
+package io.hackle.sdk.core.model
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class TargetKeyTypeDtoTest {
+    @Test
+    fun `Should return TargetKeyTypeDto when rawValue is valid`() {
+        // given
+        val rawValue = "USER_PROPERTY"
+
+        // when
+        val actual = TargetKeyTypeDto.from(rawValue)
+
+        // then
+        assertThat(actual).isNotNull()
+        assertThat(actual?.type).isEqualTo(Target.Key.Type.USER_PROPERTY)
+    }
+
+    @Test
+    fun `Should return null when rawValue is invalid`() {
+        // given
+        val rawValue = "INVALID_TYPE"
+
+        // when
+        val actual = TargetKeyTypeDto.from(rawValue)
+
+        // then
+        assertThat(actual).isNull()
+    }
+
+    @Test
+    fun `Should return null when rawValue is in lowercase`() {
+        // given
+        val rawValue = "user_property"
+
+        // when
+        val actual = TargetKeyTypeDto.from(rawValue)
+
+        // then
+        assertThat(actual).isNull()
+    }
+
+    @Test
+    fun `Should return null when rawValue is empty`() {
+        // given
+        val rawValue = ""
+
+        // when
+        val actual = TargetKeyTypeDto.from(rawValue)
+
+        // then
+        assertThat(actual).isNull()
+    }
+}


### PR DESCRIPTION
## 개요
이벤트 타겟팅에서 사용되는 Target.Key.Type의 DTO를 추가했습니다.

## 참고
https://github.com/hackle-io/hackle-android-sdk/pull/276