### PR TITLE
improve publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,21 +1,49 @@
 name: Publish
 
 on:
+  release:
+    types:
+      - prereleased
   workflow_dispatch:
 
 jobs:
   publish:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+
+      - name: Set up Snapshot version for Workflow Dispatch
+        if: ${{ github.event_name == 'workflow_dispatch'}}
+        run: |
+          CURRENT_VERSION=$(grep 'val versionName =' build.gradle.kts | sed -E 's/val versionName = "([^"]+)"/\1/')
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          SNAPSHOT_VERSION="$CURRENT_VERSION-$SHORT_SHA-SNAPSHOT"
+          sed -i "s/val versionName = \".*\"/val versionName = \"$SNAPSHOT_VERSION\"/" build.gradle.kts
+
+      - name: Verify Versions
+        if: ${{ github.event_name == 'release' }}
+        run: |
+          SDK_VERSION=$(grep 'val versionName =' build.gradle.kts | sed -E 's/val versionName = "([^"]+)"/\1/')
+          RELEASE_NAME="${{ github.event.release.name }}"
+          echo "sdk_version: $SDK_VERSION, release.name: $RELEASE_NAME"
+          if [ "$SDK_VERSION" != "$RELEASE_NAME" ]; then
+            echo "Error: sdk_version ($SDK_VERSION) does not match release.name ($RELEASE_NAME)"
+            echo "Ensure that the release name in GitHub matches the sdk_version in build.gradle.kts"
+            exit 1
+          else
+            echo "sdk_version matches release.name"
+          fi
+
       - name: Set up JDK 8
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
+
       - name: Set up Gradle
         uses: gradle/gradle-build-action@v2
         with:
           gradle-version: 7.2
+
       - name: Publish
         run: gradle clean build publishToSonatype closeAndReleaseSonatypeStagingRepository --info
         env:


### PR DESCRIPTION
## 개요
아래 사항이 변경됩니다.
- 패키지 배포는 github release의 prereleased를 통해서만 배포됩니다.
- 패키지 배포 시 `릴리즈 명`과 build.gradle.kts의 `sdkVersion`이 불일치하면 실패합니다.
- workflow_dispatch를 통해 수동으로 패키지 배포 시 snapshot으로만 배포됩니다.