### PR TITLE
fix: use PAT for release trigger and add PR auto labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,8 @@
+enhancement:
+  - head-branch: ['^feature', '^add']
+
+bug:
+  - head-branch: ['.*bug.*', '.*fix.*']
+
+maintenance:
+  - head-branch: ['.*maintenance.*', '.*migration.*', '.*refactor.*']

--- a/.github/workflows/create-prerelease.yml
+++ b/.github/workflows/create-prerelease.yml
@@ -56,7 +56,7 @@ jobs:
                 tag_name: tagName,
                 name: tagName,
                 prerelease: true,
-                generate_release_notes: true,
+                generate_release_notes: true
               });
               
               console.log(`Prerelease created successfully: ${response.data.html_url}`);

--- a/.github/workflows/create-prerelease.yml
+++ b/.github/workflows/create-prerelease.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Create prerelease
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.PAT }} 	
+          github-token: ${{ secrets.PAT }}
           script: |
             const tagName = '${{ steps.validate_tag.outputs.version }}';
             

--- a/.github/workflows/create-prerelease.yml
+++ b/.github/workflows/create-prerelease.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Create prerelease
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.PAT }} 	
           script: |
             const tagName = '${{ steps.validate_tag.outputs.version }}';
             
@@ -54,14 +55,13 @@ jobs:
                 repo: context.repo.repo,
                 tag_name: tagName,
                 name: tagName,
-                generate_release_notes: true,
                 prerelease: true,
-                draft: false
+                generate_release_notes: true,
               });
               
               console.log(`Prerelease created successfully: ${response.data.html_url}`);
               console.log(`Release ID: ${response.data.id}`);
-              
+              console.log(`Release URL: ${response.data.html_url}`);
             } catch (error) {
               if (error.status === 422 && error.response.data.errors?.[0]?.code === 'already_exists') {
                 console.log(`Release for tag ${tagName} already exists`);

--- a/.github/workflows/pr_auto_label.yml
+++ b/.github/workflows/pr_auto_label.yml
@@ -1,0 +1,23 @@
+name: PR Auto Label & Assign
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: toshimaru/auto-author-assign@v2.1.1
+
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          sync-labels: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,7 +68,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 release_id: releaseId,
-                prerelease: false
+                prerelease: false,
                 make_latest: true
               });
               

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,7 +58,7 @@ jobs:
         if: ${{ github.event_name == 'release' && github.event.release.prerelease }}
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.PAT }} 
+          github-token: ${{ secrets.PAT }}
           script: |
             const releaseId = ${{ github.event.release.id }};
             const tagName = '${{ github.event.release.tag_name }}';

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,6 +58,7 @@ jobs:
         if: ${{ github.event_name == 'release' && github.event.release.prerelease }}
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.PAT }} 
           script: |
             const releaseId = ${{ github.event.release.id }};
             const tagName = '${{ github.event.release.tag_name }}';
@@ -68,11 +69,13 @@ jobs:
                 repo: context.repo.repo,
                 release_id: releaseId,
                 prerelease: false
+                make_latest: true
               });
               
               console.log(`Successfully converted prerelease to release: ${tagName}`);
+              console.log(`Release ID: ${response.data.id}`);
               console.log(`Release URL: ${response.data.html_url}`);
-              
+              console.log(`Tag: ${response.data.tag_name}`);
             } catch (error) {
               console.error(`Failed to convert prerelease to release: ${error.message}`);
               throw error;


### PR DESCRIPTION
## 개요
prerelease 생성 시 publish 워크플로우가 자동으로 트리거되지 않는 문제를 수정합니다.
`GITHUB_TOKEN`으로 발생한 이벤트는 다른 워크플로우를 트리거하지 않으므로 PAT를 사용하도록 변경하였습니다.
또한 PR 자동 라벨링 및 작성자 assign 워크플로우를 추가하였습니다.

## 작업 내용
- `create-prerelease.yml`, `publish.yml`에서 release 생성/변환 시 PAT를 사용하도록 변경
- prerelease를 정식 release로 변환할 때 `make_latest: true` 옵션 추가
- `pr_auto_label.yml` 워크플로우 추가 (PR 자동 라벨링 및 작성자 assign)
- `labeler.yml` 추가 (브랜치 prefix 기반 라벨 매핑 정의)